### PR TITLE
Add narrow unbreakable space on Shift+AltGr+space

### DIFF
--- a/linux/us_qwerty-fr
+++ b/linux/us_qwerty-fr
@@ -59,7 +59,7 @@ xkb_symbols "qwerty-fr"
     key <AB09> { [ period,       greater,     degree,          dead_abovering  ] };
     key <AB10> { [ slash,        question,    0x01002E2E,      questiondown    ] };
 
-    key <SPCE> { [ space,        space,       nobreakspace,    nobreakspace    ] };
+    key <SPCE> { [ space,        space,       nobreakspace,    0x100202F       ] }; // espace insécable fine
 
 };
 

--- a/mac/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
+++ b/mac/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
@@ -429,7 +429,7 @@
             <key code="46" output="µ"/>
             <key code="47" output="°"/>
             <key code="48" output="&#x0009;"/>
-            <key code="49" output=" "/>
+            <key code="49" output="&#x00a0;"/>
             <key code="50" action="1"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
@@ -541,7 +541,7 @@
             <key code="46" output="µ"/>
             <key code="47" output="°"/>
             <key code="48" output="&#x0009;"/>
-            <key code="49" output=" "/>
+            <key code="49" output="&#x202f;"/>
             <key code="50" output="`"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>

--- a/windows/qwertyfr.utf8.klc
+++ b/windows/qwertyfr.utf8.klc
@@ -71,7 +71,7 @@ LAYOUT		;an extra '@' at the end is a dead key
 33	OEM_COMMA	0	002c	003c	-1	00b8@	02db@		// <, , ¸, ˛, ''
 34	OEM_PERIOD	0	002e	003e	-1	00b0	02da@		// >, , °, ˚, ''
 35	OEM_2		0	002f	003f	-1	0295	00bf		// /, ?, , ʕ, ¿
-39	SPACE		0	0020	0020	-1	00a0	00a0		// [SP], [SP], , [NBSP], [NBSP]
+39	SPACE		0	0020	0020	-1	00a0	202f		// [SP], [SP], , [NBSP], [NNBSP]
 56	OEM_102	0	003c	003e	001c	2264	2265		// <, >, [FS], ≤, ≥
 53	DECIMAL	0	002e	002e	-1	002e	002e		// ., , ., ., ''
 


### PR DESCRIPTION
Tested on Windows 10, untested on Linux.
I couldn't find how to do the macOS changes.