### PR TITLE
macOS fixes

### DIFF
--- a/mac/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
+++ b/mac/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
@@ -423,7 +423,7 @@
             <key code="40" output="ï"/>
             <key code="41" output="¶"/>
             <key code="42" output="|"/>
-            <key code="43" output=""/>
+            <key code="43" action="cedilla"/>
             <key code="44" output="⸮"/>
             <key code="45" output="ñ"/>
             <key code="46" output="µ"/>
@@ -1031,6 +1031,7 @@
         <action id="10">
             <when state="none" output="O"/>
             <when state="acute accent" output="Ó"/>
+            <when state="cedilla" output="O̧"/>
             <when state="grave accent" output="Ò"/>
             <when state="s1" output="Ó"/>
             <when state="s2" output="Ò"/>
@@ -1042,6 +1043,7 @@
         <action id="11">
             <when state="none" output="U"/>
             <when state="acute accent" output="Ú"/>
+            <when state="cedilla" output="U̧"/>
             <when state="grave accent" output="Ù"/>
             <when state="s1" output="Ú"/>
             <when state="s2" output="Ù"/>
@@ -1059,6 +1061,7 @@
         <action id="13">
             <when state="none" output="a"/>
             <when state="acute accent" output="á"/>
+            <when state="cedilla" output="a̧"/>
             <when state="grave accent" output="à"/>
             <when state="s1" output="á"/>
             <when state="s2" output="à"/>
@@ -1070,6 +1073,7 @@
         <action id="14">
             <when state="none" output="e"/>
             <when state="acute accent" output="é"/>
+            <when state="cedilla" output="ȩ"/>
             <when state="grave accent" output="è"/>
             <when state="s1" output="é"/>
             <when state="s2" output="è"/>
@@ -1080,6 +1084,7 @@
         <action id="15">
             <when state="none" output="i"/>
             <when state="acute accent" output="í"/>
+            <when state="cedilla" output="i̧"/>
             <when state="grave accent" output="ì"/>
             <when state="s1" output="í"/>
             <when state="s2" output="ì"/>
@@ -1090,12 +1095,14 @@
         <action id="16">
             <when state="none" output="n"/>
             <when state="acute accent" output="ń"/>
+            <when state="cedilla" output="ņ"/>
             <when state="s5" output="ñ"/>
             <when state="tilde" output="ñ"/>
         </action>
         <action id="17">
             <when state="none" output="o"/>
             <when state="acute accent" output="ó"/>
+            <when state="cedilla" output="o̧"/>
             <when state="grave accent" output="ò"/>
             <when state="s1" output="ó"/>
             <when state="s2" output="ò"/>
@@ -1107,6 +1114,7 @@
         <action id="18">
             <when state="none" output="u"/>
             <when state="acute accent" output="ú"/>
+            <when state="cedilla" output="u̧"/>
             <when state="grave accent" output="ù"/>
             <when state="s1" output="ú"/>
             <when state="s2" output="ù"/>
@@ -1147,6 +1155,7 @@
         <action id="6">
             <when state="none" output="A"/>
             <when state="acute accent" output="Á"/>
+            <when state="cedilla" output="A̧"/>
             <when state="grave accent" output="À"/>
             <when state="s1" output="Á"/>
             <when state="s2" output="À"/>
@@ -1158,6 +1167,7 @@
         <action id="7">
             <when state="none" output="E"/>
             <when state="acute accent" output="É"/>
+            <when state="cedilla" output="Ȩ"/>
             <when state="grave accent" output="È"/>
             <when state="s1" output="É"/>
             <when state="s2" output="È"/>
@@ -1168,6 +1178,7 @@
         <action id="8">
             <when state="none" output="I"/>
             <when state="acute accent" output="Í"/>
+            <when state="cedilla" output="I̧"/>
             <when state="grave accent" output="Ì"/>
             <when state="s1" output="Í"/>
             <when state="s2" output="Ì"/>
@@ -1178,20 +1189,24 @@
         <action id="9">
             <when state="none" output="N"/>
             <when state="acute accent" output="Ń"/>
+            <when state="cedilla" output="Ņ"/>
             <when state="s5" output="Ñ"/>
             <when state="tilde" output="Ñ"/>
         </action>
         <action id="B">
             <when state="none" output="B"/>
             <when state="acute accent" output="B́"/>
+            <when state="cedilla" output="B̧"/>
         </action>
         <action id="C">
             <when state="none" output="C"/>
             <when state="acute accent" output="Ć"/>
+            <when state="cedilla" output="Ç"/>
         </action>
         <action id="D">
             <when state="none" output="D"/>
             <when state="acute accent" output="D́"/>
+            <when state="cedilla" output="Ḑ"/>
         </action>
         <action id="F">
             <when state="none" output="F"/>
@@ -1200,11 +1215,13 @@
         <action id="G">
             <when state="none" output="G"/>
             <when state="acute accent" output="Ǵ"/>
+            <when state="cedilla" output="Ģ"/>
             <when state="tilde" output="G̃"/>
         </action>
         <action id="H">
             <when state="none" output="H"/>
             <when state="acute accent" output="H́"/>
+            <when state="cedilla" output="Ḩ"/>
         </action>
         <action id="J">
             <when state="none" output="J"/>
@@ -1214,15 +1231,18 @@
         <action id="K">
             <when state="none" output="K"/>
             <when state="acute accent" output="Ḱ"/>
+            <when state="cedilla" output="Ķ"/>
             <when state="grave accent" output="K̀"/>
         </action>
         <action id="L">
             <when state="none" output="L"/>
             <when state="acute accent" output="Ĺ"/>
+            <when state="cedilla" output="Ļ"/>
         </action>
         <action id="M">
             <when state="none" output="M"/>
             <when state="acute accent" output="Ḿ"/>
+            <when state="cedilla" output="M̧"/>
             <when state="grave accent" output="M̀"/>
             <when state="tilde" output="M̃"/>
         </action>
@@ -1234,21 +1254,25 @@
         <action id="Q">
             <when state="none" output="Q"/>
             <when state="acute accent" output="Q́"/>
+            <when state="cedilla" output="Q̧"/>
         </action>
         <action id="R">
             <when state="none" output="R"/>
             <when state="acute accent" output="Ŕ"/>
+            <when state="cedilla" output="Ŗ"/>
             <when state="grave accent" output="R̀"/>
             <when state="tilde" output="R̃"/>
         </action>
         <action id="S">
             <when state="none" output="S"/>
             <when state="acute accent" output="Ś"/>
+            <when state="cedilla" output="Ş"/>
             <when state="grave accent" output="S̀"/>
         </action>
         <action id="T">
             <when state="none" output="T"/>
             <when state="acute accent" output="T́"/>
+            <when state="cedilla" output="Ţ"/>
             <when state="grave accent" output="T̀"/>
         </action>
         <action id="V">
@@ -1265,11 +1289,13 @@
         <action id="X">
             <when state="none" output="X"/>
             <when state="acute accent" output="X́"/>
+            <when state="cedilla" output="X̧"/>
             <when state="grave accent" output="X̀"/>
         </action>
         <action id="Z">
             <when state="none" output="Z"/>
             <when state="acute accent" output="Ź"/>
+            <when state="cedilla" output="Z̧"/>
             <when state="grave accent" output="Z̀"/>
         </action>
         <action id="`">
@@ -1278,14 +1304,20 @@
         <action id="b">
             <when state="none" output="b"/>
             <when state="acute accent" output="b́"/>
+            <when state="cedilla" output="b̧"/>
         </action>
         <action id="c">
             <when state="none" output="c"/>
             <when state="acute accent" output="ć"/>
+            <when state="cedilla" output="ç"/>
+        </action>
+        <action id="cedilla">
+            <when state="none" next="cedilla"/>
         </action>
         <action id="d">
             <when state="none" output="d"/>
             <when state="acute accent" output="d́"/>
+            <when state="cedilla" output="ḑ"/>
         </action>
         <action id="f">
             <when state="none" output="f"/>
@@ -1294,11 +1326,13 @@
         <action id="g">
             <when state="none" output="g"/>
             <when state="acute accent" output="ǵ"/>
+            <when state="cedilla" output="ģ"/>
             <when state="tilde" output="g̃"/>
         </action>
         <action id="h">
             <when state="none" output="h"/>
             <when state="acute accent" output="h́"/>
+            <when state="cedilla" output="ḩ"/>
         </action>
         <action id="j">
             <when state="none" output="j"/>
@@ -1308,15 +1342,18 @@
         <action id="k">
             <when state="none" output="k"/>
             <when state="acute accent" output="ḱ"/>
+            <when state="cedilla" output="ķ"/>
             <when state="grave accent" output="k̀"/>
         </action>
         <action id="l">
             <when state="none" output="l"/>
             <when state="acute accent" output="ĺ"/>
+            <when state="cedilla" output="ļ"/>
         </action>
         <action id="m">
             <when state="none" output="m"/>
             <when state="acute accent" output="ḿ"/>
+            <when state="cedilla" output="m̧"/>
             <when state="grave accent" output="m̀"/>
             <when state="tilde" output="m̃"/>
         </action>
@@ -1328,21 +1365,25 @@
         <action id="q">
             <when state="none" output="q"/>
             <when state="acute accent" output="q́"/>
+            <when state="cedilla" output="q̧"/>
         </action>
         <action id="r">
             <when state="none" output="r"/>
             <when state="acute accent" output="ŕ"/>
+            <when state="cedilla" output="ŗ"/>
             <when state="grave accent" output="r̀"/>
             <when state="tilde" output="r̃"/>
         </action>
         <action id="s">
             <when state="none" output="s"/>
             <when state="acute accent" output="ś"/>
+            <when state="cedilla" output="ş"/>
             <when state="grave accent" output="s̀"/>
         </action>
         <action id="t">
             <when state="none" output="t"/>
             <when state="acute accent" output="t́"/>
+            <when state="cedilla" output="ţ"/>
             <when state="grave accent" output="t̀"/>
         </action>
         <action id="v">
@@ -1359,11 +1400,13 @@
         <action id="x">
             <when state="none" output="x"/>
             <when state="acute accent" output="x́"/>
+            <when state="cedilla" output="x̧"/>
             <when state="grave accent" output="x̀"/>
         </action>
         <action id="z">
             <when state="none" output="z"/>
             <when state="acute accent" output="ź"/>
+            <when state="cedilla" output="z̧"/>
             <when state="grave accent" output="z̀"/>
         </action>
         <action id="ˊ">
@@ -1372,6 +1415,7 @@
     </actions>
     <terminators>
         <when state="acute accent" output="&#x0027;"/>
+        <when state="cedilla" output="¸"/>
         <when state="grave accent" output="`"/>
         <when state="s1" output="è"/>
         <when state="s2" output="`"/>

--- a/mac/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
+++ b/mac/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
@@ -531,7 +531,7 @@
             <key code="36" output="&#x000D;"/>
             <key code="37" output="Ö"/>
             <key code="38" output="Ü"/>
-            <key code="39" output="¨"/>
+            <key code="39" action="¨"/>
             <key code="40" output="Ï"/>
             <key code="41" output="§"/>
             <key code="42" output="∅"/>
@@ -1032,6 +1032,7 @@
             <when state="none" output="O"/>
             <when state="acute accent" output="Ó"/>
             <when state="cedilla" output="O̧"/>
+            <when state="diaeresis" output="Ö"/>
             <when state="grave accent" output="Ò"/>
             <when state="s1" output="Ó"/>
             <when state="s2" output="Ò"/>
@@ -1044,6 +1045,7 @@
             <when state="none" output="U"/>
             <when state="acute accent" output="Ú"/>
             <when state="cedilla" output="U̧"/>
+            <when state="diaeresis" output="Ü"/>
             <when state="grave accent" output="Ù"/>
             <when state="s1" output="Ú"/>
             <when state="s2" output="Ù"/>
@@ -1054,6 +1056,7 @@
         <action id="12">
             <when state="none" output="Y"/>
             <when state="acute accent" output="Ý"/>
+            <when state="diaeresis" output="Ÿ"/>
             <when state="grave accent" output="Ỳ"/>
             <when state="s4" output="Ÿ"/>
             <when state="tilde" output="Ỹ"/>
@@ -1062,6 +1065,7 @@
             <when state="none" output="a"/>
             <when state="acute accent" output="á"/>
             <when state="cedilla" output="a̧"/>
+            <when state="diaeresis" output="ä"/>
             <when state="grave accent" output="à"/>
             <when state="s1" output="á"/>
             <when state="s2" output="à"/>
@@ -1074,6 +1078,7 @@
             <when state="none" output="e"/>
             <when state="acute accent" output="é"/>
             <when state="cedilla" output="ȩ"/>
+            <when state="diaeresis" output="ë"/>
             <when state="grave accent" output="è"/>
             <when state="s1" output="é"/>
             <when state="s2" output="è"/>
@@ -1085,6 +1090,7 @@
             <when state="none" output="i"/>
             <when state="acute accent" output="í"/>
             <when state="cedilla" output="i̧"/>
+            <when state="diaeresis" output="ï"/>
             <when state="grave accent" output="ì"/>
             <when state="s1" output="í"/>
             <when state="s2" output="ì"/>
@@ -1096,6 +1102,7 @@
             <when state="none" output="n"/>
             <when state="acute accent" output="ń"/>
             <when state="cedilla" output="ņ"/>
+            <when state="diaeresis" output="n̈"/>
             <when state="s5" output="ñ"/>
             <when state="tilde" output="ñ"/>
         </action>
@@ -1103,6 +1110,7 @@
             <when state="none" output="o"/>
             <when state="acute accent" output="ó"/>
             <when state="cedilla" output="o̧"/>
+            <when state="diaeresis" output="ö"/>
             <when state="grave accent" output="ò"/>
             <when state="s1" output="ó"/>
             <when state="s2" output="ò"/>
@@ -1115,6 +1123,7 @@
             <when state="none" output="u"/>
             <when state="acute accent" output="ú"/>
             <when state="cedilla" output="u̧"/>
+            <when state="diaeresis" output="ü"/>
             <when state="grave accent" output="ù"/>
             <when state="s1" output="ú"/>
             <when state="s2" output="ù"/>
@@ -1125,6 +1134,7 @@
         <action id="19">
             <when state="none" output="y"/>
             <when state="acute accent" output="ý"/>
+            <when state="diaeresis" output="ÿ"/>
             <when state="grave accent" output="ỳ"/>
             <when state="s4" output="ÿ"/>
             <when state="tilde" output="ỹ"/>
@@ -1156,6 +1166,7 @@
             <when state="none" output="A"/>
             <when state="acute accent" output="Á"/>
             <when state="cedilla" output="A̧"/>
+            <when state="diaeresis" output="Ä"/>
             <when state="grave accent" output="À"/>
             <when state="s1" output="Á"/>
             <when state="s2" output="À"/>
@@ -1168,6 +1179,7 @@
             <when state="none" output="E"/>
             <when state="acute accent" output="É"/>
             <when state="cedilla" output="Ȩ"/>
+            <when state="diaeresis" output="Ë"/>
             <when state="grave accent" output="È"/>
             <when state="s1" output="É"/>
             <when state="s2" output="È"/>
@@ -1179,6 +1191,7 @@
             <when state="none" output="I"/>
             <when state="acute accent" output="Í"/>
             <when state="cedilla" output="I̧"/>
+            <when state="diaeresis" output="Ï"/>
             <when state="grave accent" output="Ì"/>
             <when state="s1" output="Í"/>
             <when state="s2" output="Ì"/>
@@ -1190,6 +1203,7 @@
             <when state="none" output="N"/>
             <when state="acute accent" output="Ń"/>
             <when state="cedilla" output="Ņ"/>
+            <when state="diaeresis" output="N̈"/>
             <when state="s5" output="Ñ"/>
             <when state="tilde" output="Ñ"/>
         </action>
@@ -1197,11 +1211,13 @@
             <when state="none" output="B"/>
             <when state="acute accent" output="B́"/>
             <when state="cedilla" output="B̧"/>
+            <when state="diaeresis" output="B̈"/>
         </action>
         <action id="C">
             <when state="none" output="C"/>
             <when state="acute accent" output="Ć"/>
             <when state="cedilla" output="Ç"/>
+            <when state="diaeresis" output="C̈"/>
         </action>
         <action id="D">
             <when state="none" output="D"/>
@@ -1222,39 +1238,46 @@
             <when state="none" output="H"/>
             <when state="acute accent" output="H́"/>
             <when state="cedilla" output="Ḩ"/>
+            <when state="diaeresis" output="Ḧ"/>
         </action>
         <action id="J">
             <when state="none" output="J"/>
             <when state="acute accent" output="J́"/>
+            <when state="diaeresis" output="J̈"/>
             <when state="tilde" output="J̃"/>
         </action>
         <action id="K">
             <when state="none" output="K"/>
             <when state="acute accent" output="Ḱ"/>
             <when state="cedilla" output="Ķ"/>
+            <when state="diaeresis" output="K̈"/>
             <when state="grave accent" output="K̀"/>
         </action>
         <action id="L">
             <when state="none" output="L"/>
             <when state="acute accent" output="Ĺ"/>
             <when state="cedilla" output="Ļ"/>
+            <when state="diaeresis" output="L̈"/>
         </action>
         <action id="M">
             <when state="none" output="M"/>
             <when state="acute accent" output="Ḿ"/>
             <when state="cedilla" output="M̧"/>
+            <when state="diaeresis" output="M̈"/>
             <when state="grave accent" output="M̀"/>
             <when state="tilde" output="M̃"/>
         </action>
         <action id="P">
             <when state="none" output="P"/>
             <when state="acute accent" output="Ṕ"/>
+            <when state="diaeresis" output="P̈"/>
             <when state="tilde" output="P̃"/>
         </action>
         <action id="Q">
             <when state="none" output="Q"/>
             <when state="acute accent" output="Q́"/>
             <when state="cedilla" output="Q̧"/>
+            <when state="diaeresis" output="Q̈"/>
         </action>
         <action id="R">
             <when state="none" output="R"/>
@@ -1267,35 +1290,41 @@
             <when state="none" output="S"/>
             <when state="acute accent" output="Ś"/>
             <when state="cedilla" output="Ş"/>
+            <when state="diaeresis" output="S̈"/>
             <when state="grave accent" output="S̀"/>
         </action>
         <action id="T">
             <when state="none" output="T"/>
             <when state="acute accent" output="T́"/>
             <when state="cedilla" output="Ţ"/>
+            <when state="diaeresis" output="T̈"/>
             <when state="grave accent" output="T̀"/>
         </action>
         <action id="V">
             <when state="none" output="V"/>
             <when state="acute accent" output="V́"/>
+            <when state="diaeresis" output="V̈"/>
             <when state="grave accent" output="V̀"/>
             <when state="tilde" output="Ṽ"/>
         </action>
         <action id="W">
             <when state="none" output="W"/>
             <when state="acute accent" output="Ẃ"/>
+            <when state="diaeresis" output="Ẅ"/>
             <when state="grave accent" output="Ẁ"/>
         </action>
         <action id="X">
             <when state="none" output="X"/>
             <when state="acute accent" output="X́"/>
             <when state="cedilla" output="X̧"/>
+            <when state="diaeresis" output="Ẍ"/>
             <when state="grave accent" output="X̀"/>
         </action>
         <action id="Z">
             <when state="none" output="Z"/>
             <when state="acute accent" output="Ź"/>
             <when state="cedilla" output="Z̧"/>
+            <when state="diaeresis" output="Z̈"/>
             <when state="grave accent" output="Z̀"/>
         </action>
         <action id="`">
@@ -1305,11 +1334,13 @@
             <when state="none" output="b"/>
             <when state="acute accent" output="b́"/>
             <when state="cedilla" output="b̧"/>
+            <when state="diaeresis" output="b̈"/>
         </action>
         <action id="c">
             <when state="none" output="c"/>
             <when state="acute accent" output="ć"/>
             <when state="cedilla" output="ç"/>
+            <when state="diaeresis" output="c̈"/>
         </action>
         <action id="cedilla">
             <when state="none" next="cedilla"/>
@@ -1333,39 +1364,46 @@
             <when state="none" output="h"/>
             <when state="acute accent" output="h́"/>
             <when state="cedilla" output="ḩ"/>
+            <when state="diaeresis" output="ḧ"/>
         </action>
         <action id="j">
             <when state="none" output="j"/>
             <when state="acute accent" output="ȷ́"/>
+            <when state="diaeresis" output="j̈"/>
             <when state="tilde" output="j̃"/>
         </action>
         <action id="k">
             <when state="none" output="k"/>
             <when state="acute accent" output="ḱ"/>
             <when state="cedilla" output="ķ"/>
+            <when state="diaeresis" output="k̈"/>
             <when state="grave accent" output="k̀"/>
         </action>
         <action id="l">
             <when state="none" output="l"/>
             <when state="acute accent" output="ĺ"/>
             <when state="cedilla" output="ļ"/>
+            <when state="diaeresis" output="l̈"/>
         </action>
         <action id="m">
             <when state="none" output="m"/>
             <when state="acute accent" output="ḿ"/>
             <when state="cedilla" output="m̧"/>
+            <when state="diaeresis" output="m̈"/>
             <when state="grave accent" output="m̀"/>
             <when state="tilde" output="m̃"/>
         </action>
         <action id="p">
             <when state="none" output="p"/>
             <when state="acute accent" output="ṕ"/>
+            <when state="diaeresis" output="p̈"/>
             <when state="tilde" output="p̃"/>
         </action>
         <action id="q">
             <when state="none" output="q"/>
             <when state="acute accent" output="q́"/>
             <when state="cedilla" output="q̧"/>
+            <when state="diaeresis" output="q̈"/>
         </action>
         <action id="r">
             <when state="none" output="r"/>
@@ -1378,36 +1416,45 @@
             <when state="none" output="s"/>
             <when state="acute accent" output="ś"/>
             <when state="cedilla" output="ş"/>
+            <when state="diaeresis" output="s̈"/>
             <when state="grave accent" output="s̀"/>
         </action>
         <action id="t">
             <when state="none" output="t"/>
             <when state="acute accent" output="t́"/>
             <when state="cedilla" output="ţ"/>
+            <when state="diaeresis" output="ẗ"/>
             <when state="grave accent" output="t̀"/>
         </action>
         <action id="v">
             <when state="none" output="v"/>
             <when state="acute accent" output="v́"/>
+            <when state="diaeresis" output="v̈"/>
             <when state="grave accent" output="v̀"/>
             <when state="tilde" output="ṽ"/>
         </action>
         <action id="w">
             <when state="none" output="w"/>
             <when state="acute accent" output="ẃ"/>
+            <when state="diaeresis" output="ẅ"/>
             <when state="grave accent" output="ẁ"/>
         </action>
         <action id="x">
             <when state="none" output="x"/>
             <when state="acute accent" output="x́"/>
             <when state="cedilla" output="x̧"/>
+            <when state="diaeresis" output="ẍ"/>
             <when state="grave accent" output="x̀"/>
         </action>
         <action id="z">
             <when state="none" output="z"/>
             <when state="acute accent" output="ź"/>
             <when state="cedilla" output="z̧"/>
+            <when state="diaeresis" output="z̈"/>
             <when state="grave accent" output="z̀"/>
+        </action>
+        <action id="¨">
+            <when state="none" next="diaeresis"/>
         </action>
         <action id="ˊ">
             <when state="none" next="acute accent"/>
@@ -1416,6 +1463,7 @@
     <terminators>
         <when state="acute accent" output="&#x0027;"/>
         <when state="cedilla" output="¸"/>
+        <when state="diaeresis" output="¨"/>
         <when state="grave accent" output="`"/>
         <when state="s1" output="è"/>
         <when state="s2" output="`"/>

--- a/mac/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
+++ b/mac/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
@@ -46,16 +46,16 @@
         <keyMap index="0">
             <key code="0" action="13"/>
             <key code="1" action="s"/>
-            <key code="2" output="d"/>
-            <key code="3" output="f"/>
-            <key code="4" output="h"/>
+            <key code="2" action="d"/>
+            <key code="3" action="f"/>
+            <key code="4" action="h"/>
             <key code="5" action="g"/>
             <key code="6" action="z"/>
             <key code="7" action="x"/>
-            <key code="8" output="c"/>
+            <key code="8" action="c"/>
             <key code="9" action="v"/>
             <key code="10" output="§"/>
-            <key code="11" output="b"/>
+            <key code="11" action="b"/>
             <key code="12" action="q"/>
             <key code="13" action="w"/>
             <key code="14" action="14"/>
@@ -81,7 +81,7 @@
             <key code="34" action="15"/>
             <key code="35" action="p"/>
             <key code="36" output="&#x000D;"/>
-            <key code="37" output="l"/>
+            <key code="37" action="l"/>
             <key code="38" action="j"/>
             <key code="39" output="&#x0027;"/>
             <key code="40" action="k"/>
@@ -158,17 +158,17 @@
         <keyMap index="1">
             <key code="0" action="6"/>
             <key code="1" action="S"/>
-            <key code="2" output="D"/>
-            <key code="3" output="F"/>
-            <key code="4" output="H"/>
+            <key code="2" action="D"/>
+            <key code="3" action="F"/>
+            <key code="4" action="H"/>
             <key code="5" action="G"/>
             <key code="6" action="Z"/>
             <key code="7" action="X"/>
-            <key code="8" output="C"/>
+            <key code="8" action="C"/>
             <key code="9" action="V"/>
             <key code="10" output="±"/>
-            <key code="11" output="B"/>
-            <key code="12" output="Q"/>
+            <key code="11" action="B"/>
+            <key code="12" action="Q"/>
             <key code="13" action="W"/>
             <key code="14" action="7"/>
             <key code="15" action="R"/>
@@ -193,7 +193,7 @@
             <key code="34" action="8"/>
             <key code="35" action="P"/>
             <key code="36" output="&#x000D;"/>
-            <key code="37" output="L"/>
+            <key code="37" action="L"/>
             <key code="38" action="J"/>
             <key code="39" output="&#x0022;"/>
             <key code="40" action="K"/>
@@ -419,7 +419,7 @@
             <key code="36" output="&#x000D;"/>
             <key code="37" output="ö"/>
             <key code="38" output="ü"/>
-            <key code="39" output="ˊ"/>
+            <key code="39" action="ˊ"/>
             <key code="40" output="ï"/>
             <key code="41" output="¶"/>
             <key code="42" output="|"/>
@@ -1030,6 +1030,7 @@
         </action>
         <action id="10">
             <when state="none" output="O"/>
+            <when state="acute accent" output="Ó"/>
             <when state="grave accent" output="Ò"/>
             <when state="s1" output="Ó"/>
             <when state="s2" output="Ò"/>
@@ -1040,6 +1041,7 @@
         </action>
         <action id="11">
             <when state="none" output="U"/>
+            <when state="acute accent" output="Ú"/>
             <when state="grave accent" output="Ù"/>
             <when state="s1" output="Ú"/>
             <when state="s2" output="Ù"/>
@@ -1049,12 +1051,14 @@
         </action>
         <action id="12">
             <when state="none" output="Y"/>
+            <when state="acute accent" output="Ý"/>
             <when state="grave accent" output="Ỳ"/>
             <when state="s4" output="Ÿ"/>
             <when state="tilde" output="Ỹ"/>
         </action>
         <action id="13">
             <when state="none" output="a"/>
+            <when state="acute accent" output="á"/>
             <when state="grave accent" output="à"/>
             <when state="s1" output="á"/>
             <when state="s2" output="à"/>
@@ -1065,6 +1069,7 @@
         </action>
         <action id="14">
             <when state="none" output="e"/>
+            <when state="acute accent" output="é"/>
             <when state="grave accent" output="è"/>
             <when state="s1" output="é"/>
             <when state="s2" output="è"/>
@@ -1074,6 +1079,7 @@
         </action>
         <action id="15">
             <when state="none" output="i"/>
+            <when state="acute accent" output="í"/>
             <when state="grave accent" output="ì"/>
             <when state="s1" output="í"/>
             <when state="s2" output="ì"/>
@@ -1083,11 +1089,13 @@
         </action>
         <action id="16">
             <when state="none" output="n"/>
+            <when state="acute accent" output="ń"/>
             <when state="s5" output="ñ"/>
             <when state="tilde" output="ñ"/>
         </action>
         <action id="17">
             <when state="none" output="o"/>
+            <when state="acute accent" output="ó"/>
             <when state="grave accent" output="ò"/>
             <when state="s1" output="ó"/>
             <when state="s2" output="ò"/>
@@ -1098,6 +1106,7 @@
         </action>
         <action id="18">
             <when state="none" output="u"/>
+            <when state="acute accent" output="ú"/>
             <when state="grave accent" output="ù"/>
             <when state="s1" output="ú"/>
             <when state="s2" output="ù"/>
@@ -1107,6 +1116,7 @@
         </action>
         <action id="19">
             <when state="none" output="y"/>
+            <when state="acute accent" output="ý"/>
             <when state="grave accent" output="ỳ"/>
             <when state="s4" output="ÿ"/>
             <when state="tilde" output="ỹ"/>
@@ -1136,6 +1146,7 @@
         </action>
         <action id="6">
             <when state="none" output="A"/>
+            <when state="acute accent" output="Á"/>
             <when state="grave accent" output="À"/>
             <when state="s1" output="Á"/>
             <when state="s2" output="À"/>
@@ -1146,6 +1157,7 @@
         </action>
         <action id="7">
             <when state="none" output="E"/>
+            <when state="acute accent" output="É"/>
             <when state="grave accent" output="È"/>
             <when state="s1" output="É"/>
             <when state="s2" output="È"/>
@@ -1155,6 +1167,7 @@
         </action>
         <action id="8">
             <when state="none" output="I"/>
+            <when state="acute accent" output="Í"/>
             <when state="grave accent" output="Ì"/>
             <when state="s1" output="Í"/>
             <when state="s2" output="Ì"/>
@@ -1164,119 +1177,201 @@
         </action>
         <action id="9">
             <when state="none" output="N"/>
+            <when state="acute accent" output="Ń"/>
             <when state="s5" output="Ñ"/>
             <when state="tilde" output="Ñ"/>
         </action>
+        <action id="B">
+            <when state="none" output="B"/>
+            <when state="acute accent" output="B́"/>
+        </action>
+        <action id="C">
+            <when state="none" output="C"/>
+            <when state="acute accent" output="Ć"/>
+        </action>
+        <action id="D">
+            <when state="none" output="D"/>
+            <when state="acute accent" output="D́"/>
+        </action>
+        <action id="F">
+            <when state="none" output="F"/>
+            <when state="acute accent" output="F́"/>
+        </action>
         <action id="G">
             <when state="none" output="G"/>
+            <when state="acute accent" output="Ǵ"/>
             <when state="tilde" output="G̃"/>
+        </action>
+        <action id="H">
+            <when state="none" output="H"/>
+            <when state="acute accent" output="H́"/>
         </action>
         <action id="J">
             <when state="none" output="J"/>
+            <when state="acute accent" output="J́"/>
             <when state="tilde" output="J̃"/>
         </action>
         <action id="K">
             <when state="none" output="K"/>
+            <when state="acute accent" output="Ḱ"/>
             <when state="grave accent" output="K̀"/>
+        </action>
+        <action id="L">
+            <when state="none" output="L"/>
+            <when state="acute accent" output="Ĺ"/>
         </action>
         <action id="M">
             <when state="none" output="M"/>
+            <when state="acute accent" output="Ḿ"/>
             <when state="grave accent" output="M̀"/>
             <when state="tilde" output="M̃"/>
         </action>
         <action id="P">
             <when state="none" output="P"/>
+            <when state="acute accent" output="Ṕ"/>
             <when state="tilde" output="P̃"/>
+        </action>
+        <action id="Q">
+            <when state="none" output="Q"/>
+            <when state="acute accent" output="Q́"/>
         </action>
         <action id="R">
             <when state="none" output="R"/>
+            <when state="acute accent" output="Ŕ"/>
             <when state="grave accent" output="R̀"/>
             <when state="tilde" output="R̃"/>
         </action>
         <action id="S">
             <when state="none" output="S"/>
+            <when state="acute accent" output="Ś"/>
             <when state="grave accent" output="S̀"/>
         </action>
         <action id="T">
             <when state="none" output="T"/>
+            <when state="acute accent" output="T́"/>
             <when state="grave accent" output="T̀"/>
         </action>
         <action id="V">
             <when state="none" output="V"/>
+            <when state="acute accent" output="V́"/>
             <when state="grave accent" output="V̀"/>
             <when state="tilde" output="Ṽ"/>
         </action>
         <action id="W">
             <when state="none" output="W"/>
+            <when state="acute accent" output="Ẃ"/>
             <when state="grave accent" output="Ẁ"/>
         </action>
         <action id="X">
             <when state="none" output="X"/>
+            <when state="acute accent" output="X́"/>
             <when state="grave accent" output="X̀"/>
         </action>
         <action id="Z">
             <when state="none" output="Z"/>
+            <when state="acute accent" output="Ź"/>
             <when state="grave accent" output="Z̀"/>
         </action>
         <action id="`">
             <when state="none" next="tilde"/>
         </action>
+        <action id="b">
+            <when state="none" output="b"/>
+            <when state="acute accent" output="b́"/>
+        </action>
+        <action id="c">
+            <when state="none" output="c"/>
+            <when state="acute accent" output="ć"/>
+        </action>
+        <action id="d">
+            <when state="none" output="d"/>
+            <when state="acute accent" output="d́"/>
+        </action>
+        <action id="f">
+            <when state="none" output="f"/>
+            <when state="acute accent" output="f́"/>
+        </action>
         <action id="g">
             <when state="none" output="g"/>
+            <when state="acute accent" output="ǵ"/>
             <when state="tilde" output="g̃"/>
+        </action>
+        <action id="h">
+            <when state="none" output="h"/>
+            <when state="acute accent" output="h́"/>
         </action>
         <action id="j">
             <when state="none" output="j"/>
+            <when state="acute accent" output="ȷ́"/>
             <when state="tilde" output="j̃"/>
         </action>
         <action id="k">
             <when state="none" output="k"/>
+            <when state="acute accent" output="ḱ"/>
             <when state="grave accent" output="k̀"/>
+        </action>
+        <action id="l">
+            <when state="none" output="l"/>
+            <when state="acute accent" output="ĺ"/>
         </action>
         <action id="m">
             <when state="none" output="m"/>
+            <when state="acute accent" output="ḿ"/>
             <when state="grave accent" output="m̀"/>
             <when state="tilde" output="m̃"/>
         </action>
         <action id="p">
             <when state="none" output="p"/>
+            <when state="acute accent" output="ṕ"/>
             <when state="tilde" output="p̃"/>
         </action>
         <action id="q">
             <when state="none" output="q"/>
+            <when state="acute accent" output="q́"/>
         </action>
         <action id="r">
             <when state="none" output="r"/>
+            <when state="acute accent" output="ŕ"/>
             <when state="grave accent" output="r̀"/>
             <when state="tilde" output="r̃"/>
         </action>
         <action id="s">
             <when state="none" output="s"/>
+            <when state="acute accent" output="ś"/>
             <when state="grave accent" output="s̀"/>
         </action>
         <action id="t">
             <when state="none" output="t"/>
+            <when state="acute accent" output="t́"/>
             <when state="grave accent" output="t̀"/>
         </action>
         <action id="v">
             <when state="none" output="v"/>
+            <when state="acute accent" output="v́"/>
             <when state="grave accent" output="v̀"/>
             <when state="tilde" output="ṽ"/>
         </action>
         <action id="w">
             <when state="none" output="w"/>
+            <when state="acute accent" output="ẃ"/>
             <when state="grave accent" output="ẁ"/>
         </action>
         <action id="x">
             <when state="none" output="x"/>
+            <when state="acute accent" output="x́"/>
             <when state="grave accent" output="x̀"/>
         </action>
         <action id="z">
             <when state="none" output="z"/>
+            <when state="acute accent" output="ź"/>
             <when state="grave accent" output="z̀"/>
+        </action>
+        <action id="ˊ">
+            <when state="none" next="acute accent"/>
         </action>
     </actions>
     <terminators>
+        <when state="acute accent" output="&#x0027;"/>
         <when state="grave accent" output="`"/>
         <when state="s1" output="è"/>
         <when state="s2" output="`"/>

--- a/mac/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
+++ b/mac/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
@@ -383,13 +383,13 @@
             <key code="0" output="à"/>
             <key code="1" output="æ"/>
             <key code="2" output="ë"/>
-            <key code="3" output=""/>
+            <key code="3" output="ε"/>
             <key code="4" output="ÿ"/>
-            <key code="5" output=""/>
+            <key code="5" output="α"/>
             <key code="6" output="ä"/>
             <key code="7" output="×"/>
             <key code="8" output="ç"/>
-            <key code="9" output="√"/>
+            <key code="9" output="ω"/>
             <key code="10" output="§"/>
             <key code="11" output="ß"/>
             <key code="12" output="â"/>
@@ -397,7 +397,7 @@
             <key code="14" output="è"/>
             <key code="15" output="®"/>
             <key code="16" output="¥"/>
-            <key code="17" output="†"/>
+            <key code="17" output="π"/>
             <key code="18" output="¹"/>
             <key code="19" output="²"/>
             <key code="20" output="³"/>
@@ -422,7 +422,7 @@
             <key code="39" action="ˊ"/>
             <key code="40" output="ï"/>
             <key code="41" output="¶"/>
-            <key code="42" output="|"/>
+            <key code="42" output="¦"/>
             <key code="43" action="cedilla"/>
             <key code="44" output="⸮"/>
             <key code="45" output="ñ"/>
@@ -495,23 +495,23 @@
             <key code="0" output="À"/>
             <key code="1" output="Æ"/>
             <key code="2" output="Ë"/>
-            <key code="3" output=""/>
+            <key code="3" output="Δ"/>
             <key code="4" output="Ÿ"/>
-            <key code="5" output=""/>
+            <key code="5" output="β"/>
             <key code="6" output="Ä"/>
             <key code="7" output="÷"/>
             <key code="8" output="Ç"/>
-            <key code="9" output=""/>
+            <key code="9" output="Ω"/>
             <key code="10" output="±"/>
             <key code="11" output="ß"/>
             <key code="12" output="Â"/>
             <key code="13" output="É"/>
             <key code="14" output="È"/>
             <key code="15" output="©"/>
-            <key code="16" output="Á"/>
-            <key code="17" output="ˇ"/>
+            <key code="16" output="¤"/>
+            <key code="17" output="Π"/>
             <key code="18" output="¡"/>
-            <key code="19" output=""/>
+            <key code="19" output="˝"/>
             <key code="20" output="¯"/>
             <key code="21" output="Ê"/>
             <key code="22" action="caron"/>

--- a/mac/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
+++ b/mac/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
@@ -402,7 +402,7 @@
             <key code="19" output="²"/>
             <key code="20" output="³"/>
             <key code="21" output="ê"/>
-            <key code="22" output=""/>
+            <key code="22" action="circumflex"/>
             <key code="23" output="€"/>
             <key code="24" output="≠"/>
             <key code="25" output="î"/>
@@ -1032,6 +1032,7 @@
             <when state="none" output="O"/>
             <when state="acute accent" output="Ó"/>
             <when state="cedilla" output="O̧"/>
+            <when state="circumflex" output="Ô"/>
             <when state="diaeresis" output="Ö"/>
             <when state="grave accent" output="Ò"/>
             <when state="s1" output="Ó"/>
@@ -1045,6 +1046,7 @@
             <when state="none" output="U"/>
             <when state="acute accent" output="Ú"/>
             <when state="cedilla" output="U̧"/>
+            <when state="circumflex" output="Û"/>
             <when state="diaeresis" output="Ü"/>
             <when state="grave accent" output="Ù"/>
             <when state="s1" output="Ú"/>
@@ -1056,6 +1058,7 @@
         <action id="12">
             <when state="none" output="Y"/>
             <when state="acute accent" output="Ý"/>
+            <when state="circumflex" output="Ŷ"/>
             <when state="diaeresis" output="Ÿ"/>
             <when state="grave accent" output="Ỳ"/>
             <when state="s4" output="Ÿ"/>
@@ -1065,6 +1068,7 @@
             <when state="none" output="a"/>
             <when state="acute accent" output="á"/>
             <when state="cedilla" output="a̧"/>
+            <when state="circumflex" output="â"/>
             <when state="diaeresis" output="ä"/>
             <when state="grave accent" output="à"/>
             <when state="s1" output="á"/>
@@ -1078,6 +1082,7 @@
             <when state="none" output="e"/>
             <when state="acute accent" output="é"/>
             <when state="cedilla" output="ȩ"/>
+            <when state="circumflex" output="ê"/>
             <when state="diaeresis" output="ë"/>
             <when state="grave accent" output="è"/>
             <when state="s1" output="é"/>
@@ -1090,6 +1095,7 @@
             <when state="none" output="i"/>
             <when state="acute accent" output="í"/>
             <when state="cedilla" output="i̧"/>
+            <when state="circumflex" output="î"/>
             <when state="diaeresis" output="ï"/>
             <when state="grave accent" output="ì"/>
             <when state="s1" output="í"/>
@@ -1102,6 +1108,7 @@
             <when state="none" output="n"/>
             <when state="acute accent" output="ń"/>
             <when state="cedilla" output="ņ"/>
+            <when state="circumflex" output="n̂"/>
             <when state="diaeresis" output="n̈"/>
             <when state="s5" output="ñ"/>
             <when state="tilde" output="ñ"/>
@@ -1110,6 +1117,7 @@
             <when state="none" output="o"/>
             <when state="acute accent" output="ó"/>
             <when state="cedilla" output="o̧"/>
+            <when state="circumflex" output="ô"/>
             <when state="diaeresis" output="ö"/>
             <when state="grave accent" output="ò"/>
             <when state="s1" output="ó"/>
@@ -1123,6 +1131,7 @@
             <when state="none" output="u"/>
             <when state="acute accent" output="ú"/>
             <when state="cedilla" output="u̧"/>
+            <when state="circumflex" output="û"/>
             <when state="diaeresis" output="ü"/>
             <when state="grave accent" output="ù"/>
             <when state="s1" output="ú"/>
@@ -1134,6 +1143,7 @@
         <action id="19">
             <when state="none" output="y"/>
             <when state="acute accent" output="ý"/>
+            <when state="circumflex" output="ŷ"/>
             <when state="diaeresis" output="ÿ"/>
             <when state="grave accent" output="ỳ"/>
             <when state="s4" output="ÿ"/>
@@ -1166,6 +1176,7 @@
             <when state="none" output="A"/>
             <when state="acute accent" output="Á"/>
             <when state="cedilla" output="A̧"/>
+            <when state="circumflex" output="Â"/>
             <when state="diaeresis" output="Ä"/>
             <when state="grave accent" output="À"/>
             <when state="s1" output="Á"/>
@@ -1179,6 +1190,7 @@
             <when state="none" output="E"/>
             <when state="acute accent" output="É"/>
             <when state="cedilla" output="Ȩ"/>
+            <when state="circumflex" output="Ê"/>
             <when state="diaeresis" output="Ë"/>
             <when state="grave accent" output="È"/>
             <when state="s1" output="É"/>
@@ -1191,6 +1203,7 @@
             <when state="none" output="I"/>
             <when state="acute accent" output="Í"/>
             <when state="cedilla" output="I̧"/>
+            <when state="circumflex" output="Î"/>
             <when state="diaeresis" output="Ï"/>
             <when state="grave accent" output="Ì"/>
             <when state="s1" output="Í"/>
@@ -1203,6 +1216,7 @@
             <when state="none" output="N"/>
             <when state="acute accent" output="Ń"/>
             <when state="cedilla" output="Ņ"/>
+            <when state="circumflex" output="N̂"/>
             <when state="diaeresis" output="N̈"/>
             <when state="s5" output="Ñ"/>
             <when state="tilde" output="Ñ"/>
@@ -1211,18 +1225,21 @@
             <when state="none" output="B"/>
             <when state="acute accent" output="B́"/>
             <when state="cedilla" output="B̧"/>
+            <when state="circumflex" output="B̂"/>
             <when state="diaeresis" output="B̈"/>
         </action>
         <action id="C">
             <when state="none" output="C"/>
             <when state="acute accent" output="Ć"/>
             <when state="cedilla" output="Ç"/>
+            <when state="circumflex" output="Ĉ"/>
             <when state="diaeresis" output="C̈"/>
         </action>
         <action id="D">
             <when state="none" output="D"/>
             <when state="acute accent" output="D́"/>
             <when state="cedilla" output="Ḑ"/>
+            <when state="circumflex" output="D̂"/>
         </action>
         <action id="F">
             <when state="none" output="F"/>
@@ -1232,17 +1249,20 @@
             <when state="none" output="G"/>
             <when state="acute accent" output="Ǵ"/>
             <when state="cedilla" output="Ģ"/>
+            <when state="circumflex" output="Ĝ"/>
             <when state="tilde" output="G̃"/>
         </action>
         <action id="H">
             <when state="none" output="H"/>
             <when state="acute accent" output="H́"/>
             <when state="cedilla" output="Ḩ"/>
+            <when state="circumflex" output="Ĥ"/>
             <when state="diaeresis" output="Ḧ"/>
         </action>
         <action id="J">
             <when state="none" output="J"/>
             <when state="acute accent" output="J́"/>
+            <when state="circumflex" output="Ĵ"/>
             <when state="diaeresis" output="J̈"/>
             <when state="tilde" output="J̃"/>
         </action>
@@ -1250,6 +1270,7 @@
             <when state="none" output="K"/>
             <when state="acute accent" output="Ḱ"/>
             <when state="cedilla" output="Ķ"/>
+            <when state="circumflex" output="K̂"/>
             <when state="diaeresis" output="K̈"/>
             <when state="grave accent" output="K̀"/>
         </action>
@@ -1257,12 +1278,14 @@
             <when state="none" output="L"/>
             <when state="acute accent" output="Ĺ"/>
             <when state="cedilla" output="Ļ"/>
+            <when state="circumflex" output="L̂"/>
             <when state="diaeresis" output="L̈"/>
         </action>
         <action id="M">
             <when state="none" output="M"/>
             <when state="acute accent" output="Ḿ"/>
             <when state="cedilla" output="M̧"/>
+            <when state="circumflex" output="M̂"/>
             <when state="diaeresis" output="M̈"/>
             <when state="grave accent" output="M̀"/>
             <when state="tilde" output="M̃"/>
@@ -1283,6 +1306,7 @@
             <when state="none" output="R"/>
             <when state="acute accent" output="Ŕ"/>
             <when state="cedilla" output="Ŗ"/>
+            <when state="circumflex" output="R̂"/>
             <when state="grave accent" output="R̀"/>
             <when state="tilde" output="R̃"/>
         </action>
@@ -1290,6 +1314,7 @@
             <when state="none" output="S"/>
             <when state="acute accent" output="Ś"/>
             <when state="cedilla" output="Ş"/>
+            <when state="circumflex" output="Ŝ"/>
             <when state="diaeresis" output="S̈"/>
             <when state="grave accent" output="S̀"/>
         </action>
@@ -1297,12 +1322,14 @@
             <when state="none" output="T"/>
             <when state="acute accent" output="T́"/>
             <when state="cedilla" output="Ţ"/>
+            <when state="circumflex" output="T̂"/>
             <when state="diaeresis" output="T̈"/>
             <when state="grave accent" output="T̀"/>
         </action>
         <action id="V">
             <when state="none" output="V"/>
             <when state="acute accent" output="V́"/>
+            <when state="circumflex" output="V̂"/>
             <when state="diaeresis" output="V̈"/>
             <when state="grave accent" output="V̀"/>
             <when state="tilde" output="Ṽ"/>
@@ -1310,6 +1337,7 @@
         <action id="W">
             <when state="none" output="W"/>
             <when state="acute accent" output="Ẃ"/>
+            <when state="circumflex" output="Ŵ"/>
             <when state="diaeresis" output="Ẅ"/>
             <when state="grave accent" output="Ẁ"/>
         </action>
@@ -1317,6 +1345,7 @@
             <when state="none" output="X"/>
             <when state="acute accent" output="X́"/>
             <when state="cedilla" output="X̧"/>
+            <when state="circumflex" output="X̂"/>
             <when state="diaeresis" output="Ẍ"/>
             <when state="grave accent" output="X̀"/>
         </action>
@@ -1324,6 +1353,7 @@
             <when state="none" output="Z"/>
             <when state="acute accent" output="Ź"/>
             <when state="cedilla" output="Z̧"/>
+            <when state="circumflex" output="Ẑ"/>
             <when state="diaeresis" output="Z̈"/>
             <when state="grave accent" output="Z̀"/>
         </action>
@@ -1334,21 +1364,27 @@
             <when state="none" output="b"/>
             <when state="acute accent" output="b́"/>
             <when state="cedilla" output="b̧"/>
+            <when state="circumflex" output="b̂"/>
             <when state="diaeresis" output="b̈"/>
         </action>
         <action id="c">
             <when state="none" output="c"/>
             <when state="acute accent" output="ć"/>
             <when state="cedilla" output="ç"/>
+            <when state="circumflex" output="ĉ"/>
             <when state="diaeresis" output="c̈"/>
         </action>
         <action id="cedilla">
             <when state="none" next="cedilla"/>
         </action>
+        <action id="circumflex">
+            <when state="none" next="circumflex"/>
+        </action>
         <action id="d">
             <when state="none" output="d"/>
             <when state="acute accent" output="d́"/>
             <when state="cedilla" output="ḑ"/>
+            <when state="circumflex" output="d̂"/>
         </action>
         <action id="f">
             <when state="none" output="f"/>
@@ -1358,17 +1394,20 @@
             <when state="none" output="g"/>
             <when state="acute accent" output="ǵ"/>
             <when state="cedilla" output="ģ"/>
+            <when state="circumflex" output="ĝ"/>
             <when state="tilde" output="g̃"/>
         </action>
         <action id="h">
             <when state="none" output="h"/>
             <when state="acute accent" output="h́"/>
             <when state="cedilla" output="ḩ"/>
+            <when state="circumflex" output="ĥ"/>
             <when state="diaeresis" output="ḧ"/>
         </action>
         <action id="j">
             <when state="none" output="j"/>
             <when state="acute accent" output="ȷ́"/>
+            <when state="circumflex" output="ĵ"/>
             <when state="diaeresis" output="j̈"/>
             <when state="tilde" output="j̃"/>
         </action>
@@ -1376,6 +1415,7 @@
             <when state="none" output="k"/>
             <when state="acute accent" output="ḱ"/>
             <when state="cedilla" output="ķ"/>
+            <when state="circumflex" output="k̂"/>
             <when state="diaeresis" output="k̈"/>
             <when state="grave accent" output="k̀"/>
         </action>
@@ -1383,12 +1423,14 @@
             <when state="none" output="l"/>
             <when state="acute accent" output="ĺ"/>
             <when state="cedilla" output="ļ"/>
+            <when state="circumflex" output="l̂"/>
             <when state="diaeresis" output="l̈"/>
         </action>
         <action id="m">
             <when state="none" output="m"/>
             <when state="acute accent" output="ḿ"/>
             <when state="cedilla" output="m̧"/>
+            <when state="circumflex" output="m̂"/>
             <when state="diaeresis" output="m̈"/>
             <when state="grave accent" output="m̀"/>
             <when state="tilde" output="m̃"/>
@@ -1409,6 +1451,7 @@
             <when state="none" output="r"/>
             <when state="acute accent" output="ŕ"/>
             <when state="cedilla" output="ŗ"/>
+            <when state="circumflex" output="r̂"/>
             <when state="grave accent" output="r̀"/>
             <when state="tilde" output="r̃"/>
         </action>
@@ -1416,6 +1459,7 @@
             <when state="none" output="s"/>
             <when state="acute accent" output="ś"/>
             <when state="cedilla" output="ş"/>
+            <when state="circumflex" output="ŝ"/>
             <when state="diaeresis" output="s̈"/>
             <when state="grave accent" output="s̀"/>
         </action>
@@ -1423,12 +1467,14 @@
             <when state="none" output="t"/>
             <when state="acute accent" output="t́"/>
             <when state="cedilla" output="ţ"/>
+            <when state="circumflex" output="t̂"/>
             <when state="diaeresis" output="ẗ"/>
             <when state="grave accent" output="t̀"/>
         </action>
         <action id="v">
             <when state="none" output="v"/>
             <when state="acute accent" output="v́"/>
+            <when state="circumflex" output="v̂"/>
             <when state="diaeresis" output="v̈"/>
             <when state="grave accent" output="v̀"/>
             <when state="tilde" output="ṽ"/>
@@ -1436,6 +1482,7 @@
         <action id="w">
             <when state="none" output="w"/>
             <when state="acute accent" output="ẃ"/>
+            <when state="circumflex" output="ŵ"/>
             <when state="diaeresis" output="ẅ"/>
             <when state="grave accent" output="ẁ"/>
         </action>
@@ -1443,6 +1490,7 @@
             <when state="none" output="x"/>
             <when state="acute accent" output="x́"/>
             <when state="cedilla" output="x̧"/>
+            <when state="circumflex" output="x̂"/>
             <when state="diaeresis" output="ẍ"/>
             <when state="grave accent" output="x̀"/>
         </action>
@@ -1450,6 +1498,7 @@
             <when state="none" output="z"/>
             <when state="acute accent" output="ź"/>
             <when state="cedilla" output="z̧"/>
+            <when state="circumflex" output="ẑ"/>
             <when state="diaeresis" output="z̈"/>
             <when state="grave accent" output="z̀"/>
         </action>
@@ -1463,6 +1512,7 @@
     <terminators>
         <when state="acute accent" output="&#x0027;"/>
         <when state="cedilla" output="¸"/>
+        <when state="circumflex" output="ˆ"/>
         <when state="diaeresis" output="¨"/>
         <when state="grave accent" output="`"/>
         <when state="s1" output="è"/>

--- a/mac/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
+++ b/mac/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
@@ -1,17 +1,17 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE keyboard PUBLIC "" "file://localhost/System/Library/DTDs/KeyboardLayout.dtd">
-<!--Last edited by Ukelele version 2.1.10 on 2012-02-21 at 00:23 (PST)-->
+<?xml version="1.1" encoding="UTF-8"?>
+<!DOCTYPE keyboard SYSTEM "file://localhost/System/Library/DTDs/KeyboardLayout.dtd">
+<!--Last edited by Ukelele version 3.4.2.314 on 2020-03-03 at 00:23 (CET)-->
 <!--Created by Ukelele version 2.1.10 on 2012-02-20 at 23:06 (PST)-->
 <keyboard group="0" id="0" name="qwerty-fr" maxout="1">
     <layouts>
-        <layout first="0" last="17" modifiers="f4" mapSet="16c"/>
-        <layout first="18" last="18" modifiers="f4" mapSet="994"/>
-        <layout first="21" last="23" modifiers="f4" mapSet="994"/>
-        <layout first="30" last="30" modifiers="f4" mapSet="994"/>
-        <layout first="194" last="194" modifiers="f4" mapSet="994"/>
-        <layout first="197" last="197" modifiers="f4" mapSet="994"/>
-        <layout first="200" last="201" modifiers="f4" mapSet="994"/>
-        <layout first="206" last="207" modifiers="f4" mapSet="994"/>
+        <layout first="0" last="17" mapSet="16c" modifiers="f4"/>
+        <layout first="18" last="18" mapSet="994" modifiers="f4"/>
+        <layout first="21" last="23" mapSet="994" modifiers="f4"/>
+        <layout first="30" last="30" mapSet="994" modifiers="f4"/>
+        <layout first="194" last="194" mapSet="994" modifiers="f4"/>
+        <layout first="197" last="197" mapSet="994" modifiers="f4"/>
+        <layout first="200" last="201" mapSet="994" modifiers="f4"/>
+        <layout first="206" last="207" mapSet="994" modifiers="f4"/>
     </layouts>
     <modifierMap id="f4" defaultIndex="7">
         <keyMapSelect mapIndex="0">
@@ -45,23 +45,23 @@
     <keyMapSet id="16c">
         <keyMap index="0">
             <key code="0" action="13"/>
-            <key code="1" output="s"/>
+            <key code="1" action="s"/>
             <key code="2" output="d"/>
             <key code="3" output="f"/>
             <key code="4" output="h"/>
             <key code="5" output="g"/>
-            <key code="6" output="z"/>
-            <key code="7" output="x"/>
+            <key code="6" action="z"/>
+            <key code="7" action="x"/>
             <key code="8" output="c"/>
-            <key code="9" output="v"/>
+            <key code="9" action="v"/>
             <key code="10" output="§"/>
             <key code="11" output="b"/>
-            <key code="12" output="q"/>
-            <key code="13" output="w"/>
+            <key code="12" action="q"/>
+            <key code="13" action="w"/>
             <key code="14" action="14"/>
-            <key code="15" output="r"/>
+            <key code="15" action="r"/>
             <key code="16" action="19"/>
-            <key code="17" output="t"/>
+            <key code="17" action="t"/>
             <key code="18" output="1"/>
             <key code="19" output="2"/>
             <key code="20" output="3"/>
@@ -84,13 +84,13 @@
             <key code="37" output="l"/>
             <key code="38" output="j"/>
             <key code="39" output="&#x0027;"/>
-            <key code="40" output="k"/>
+            <key code="40" action="k"/>
             <key code="41" output=";"/>
             <key code="42" output="\"/>
             <key code="43" output=","/>
             <key code="44" output="/"/>
             <key code="45" action="16"/>
-            <key code="46" output="m"/>
+            <key code="46" action="m"/>
             <key code="47" output="."/>
             <key code="48" output="&#x0009;"/>
             <key code="49" action="5"/>
@@ -157,23 +157,23 @@
         </keyMap>
         <keyMap index="1">
             <key code="0" action="6"/>
-            <key code="1" output="S"/>
+            <key code="1" action="S"/>
             <key code="2" output="D"/>
             <key code="3" output="F"/>
             <key code="4" output="H"/>
             <key code="5" output="G"/>
-            <key code="6" output="Z"/>
-            <key code="7" output="X"/>
+            <key code="6" action="Z"/>
+            <key code="7" action="X"/>
             <key code="8" output="C"/>
-            <key code="9" output="V"/>
+            <key code="9" action="V"/>
             <key code="10" output="±"/>
             <key code="11" output="B"/>
             <key code="12" output="Q"/>
-            <key code="13" output="W"/>
+            <key code="13" action="W"/>
             <key code="14" action="7"/>
-            <key code="15" output="R"/>
+            <key code="15" action="R"/>
             <key code="16" action="12"/>
-            <key code="17" output="T"/>
+            <key code="17" action="T"/>
             <key code="18" output="!"/>
             <key code="19" output="@"/>
             <key code="20" output="#"/>
@@ -196,13 +196,13 @@
             <key code="37" output="L"/>
             <key code="38" output="J"/>
             <key code="39" output="&#x0022;"/>
-            <key code="40" output="K"/>
+            <key code="40" action="K"/>
             <key code="41" output=":"/>
             <key code="42" output="|"/>
             <key code="43" output="&#x003C;"/>
             <key code="44" output="?"/>
             <key code="45" action="9"/>
-            <key code="46" output="M"/>
+            <key code="46" action="M"/>
             <key code="47" output="&#x003E;"/>
             <key code="48" output="&#x0009;"/>
             <key code="49" action="5"/>
@@ -430,7 +430,7 @@
             <key code="47" output="°"/>
             <key code="48" output="&#x0009;"/>
             <key code="49" output="&#x00a0;"/>
-            <key code="50" action="1"/>
+            <key code="50" action="21"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
             <key code="53" output="&#x001B;"/>
@@ -1028,8 +1028,87 @@
         <action id="1">
             <when state="none" next="s2"/>
         </action>
+        <action id="10">
+            <when state="none" output="O"/>
+            <when state="grave accent" output="Ò"/>
+            <when state="s1" output="Ó"/>
+            <when state="s2" output="Ò"/>
+            <when state="s3" output="Ô"/>
+            <when state="s4" output="Ö"/>
+            <when state="s5" output="Õ"/>
+        </action>
+        <action id="11">
+            <when state="none" output="U"/>
+            <when state="grave accent" output="Ù"/>
+            <when state="s1" output="Ú"/>
+            <when state="s2" output="Ù"/>
+            <when state="s3" output="Û"/>
+            <when state="s4" output="Ü"/>
+        </action>
+        <action id="12">
+            <when state="none" output="Y"/>
+            <when state="grave accent" output="Ỳ"/>
+            <when state="s4" output="Ÿ"/>
+        </action>
+        <action id="13">
+            <when state="none" output="a"/>
+            <when state="grave accent" output="à"/>
+            <when state="s1" output="á"/>
+            <when state="s2" output="à"/>
+            <when state="s3" output="â"/>
+            <when state="s4" output="ä"/>
+            <when state="s5" output="ã"/>
+        </action>
+        <action id="14">
+            <when state="none" output="e"/>
+            <when state="grave accent" output="è"/>
+            <when state="s1" output="é"/>
+            <when state="s2" output="è"/>
+            <when state="s3" output="ê"/>
+            <when state="s4" output="ë"/>
+        </action>
+        <action id="15">
+            <when state="none" output="i"/>
+            <when state="grave accent" output="ì"/>
+            <when state="s1" output="í"/>
+            <when state="s2" output="ì"/>
+            <when state="s3" output="î"/>
+            <when state="s4" output="ï"/>
+        </action>
+        <action id="16">
+            <when state="none" output="n"/>
+            <when state="s5" output="ñ"/>
+        </action>
+        <action id="17">
+            <when state="none" output="o"/>
+            <when state="grave accent" output="ò"/>
+            <when state="s1" output="ó"/>
+            <when state="s2" output="ò"/>
+            <when state="s3" output="ô"/>
+            <when state="s4" output="ö"/>
+            <when state="s5" output="õ"/>
+        </action>
+        <action id="18">
+            <when state="none" output="u"/>
+            <when state="grave accent" output="ù"/>
+            <when state="s1" output="ú"/>
+            <when state="s2" output="ù"/>
+            <when state="s3" output="û"/>
+            <when state="s4" output="ü"/>
+        </action>
+        <action id="19">
+            <when state="none" output="y"/>
+            <when state="grave accent" output="ỳ"/>
+            <when state="s4" output="ÿ"/>
+        </action>
         <action id="2">
             <when state="none" next="s3"/>
+        </action>
+        <action id="20">
+            <when state="none" next="s2"/>
+        </action>
+        <action id="21">
+            <when state="none" next="grave accent"/>
         </action>
         <action id="3">
             <when state="none" next="s4"/>
@@ -1047,6 +1126,7 @@
         </action>
         <action id="6">
             <when state="none" output="A"/>
+            <when state="grave accent" output="À"/>
             <when state="s1" output="Á"/>
             <when state="s2" output="À"/>
             <when state="s3" output="Â"/>
@@ -1055,6 +1135,7 @@
         </action>
         <action id="7">
             <when state="none" output="E"/>
+            <when state="grave accent" output="È"/>
             <when state="s1" output="É"/>
             <when state="s2" output="È"/>
             <when state="s3" output="Ê"/>
@@ -1062,6 +1143,7 @@
         </action>
         <action id="8">
             <when state="none" output="I"/>
+            <when state="grave accent" output="Ì"/>
             <when state="s1" output="Í"/>
             <when state="s2" output="Ì"/>
             <when state="s3" output="Î"/>
@@ -1071,72 +1153,84 @@
             <when state="none" output="N"/>
             <when state="s5" output="Ñ"/>
         </action>
-        <action id="10">
-            <when state="none" output="O"/>
-            <when state="s1" output="Ó"/>
-            <when state="s2" output="Ò"/>
-            <when state="s3" output="Ô"/>
-            <when state="s4" output="Ö"/>
-            <when state="s5" output="Õ"/>
+        <action id="K">
+            <when state="none" output="K"/>
+            <when state="grave accent" output="K̀"/>
         </action>
-        <action id="11">
-            <when state="none" output="U"/>
-            <when state="s1" output="Ú"/>
-            <when state="s2" output="Ù"/>
-            <when state="s3" output="Û"/>
-            <when state="s4" output="Ü"/>
+        <action id="M">
+            <when state="none" output="M"/>
+            <when state="grave accent" output="M̀"/>
         </action>
-        <action id="12">
-            <when state="none" output="Y"/>
-            <when state="s4" output="Ÿ"/>
+        <action id="R">
+            <when state="none" output="R"/>
+            <when state="grave accent" output="R̀"/>
         </action>
-        <action id="13">
-            <when state="none" output="a"/>
-            <when state="s1" output="á"/>
-            <when state="s2" output="à"/>
-            <when state="s3" output="â"/>
-            <when state="s4" output="ä"/>
-            <when state="s5" output="ã"/>
+        <action id="S">
+            <when state="none" output="S"/>
+            <when state="grave accent" output="S̀"/>
         </action>
-        <action id="14">
-            <when state="none" output="e"/>
-            <when state="s1" output="é"/>
-            <when state="s2" output="è"/>
-            <when state="s3" output="ê"/>
-            <when state="s4" output="ë"/>
+        <action id="T">
+            <when state="none" output="T"/>
+            <when state="grave accent" output="T̀"/>
         </action>
-        <action id="15">
-            <when state="none" output="i"/>
-            <when state="s1" output="í"/>
-            <when state="s2" output="ì"/>
-            <when state="s3" output="î"/>
-            <when state="s4" output="ï"/>
+        <action id="V">
+            <when state="none" output="V"/>
+            <when state="grave accent" output="V̀"/>
         </action>
-        <action id="16">
-            <when state="none" output="n"/>
-            <when state="s5" output="ñ"/>
+        <action id="W">
+            <when state="none" output="W"/>
+            <when state="grave accent" output="Ẁ"/>
         </action>
-        <action id="17">
-            <when state="none" output="o"/>
-            <when state="s1" output="ó"/>
-            <when state="s2" output="ò"/>
-            <when state="s3" output="ô"/>
-            <when state="s4" output="ö"/>
-            <when state="s5" output="õ"/>
+        <action id="X">
+            <when state="none" output="X"/>
+            <when state="grave accent" output="X̀"/>
         </action>
-        <action id="18">
-            <when state="none" output="u"/>
-            <when state="s1" output="ú"/>
-            <when state="s2" output="ù"/>
-            <when state="s3" output="û"/>
-            <when state="s4" output="ü"/>
+        <action id="Z">
+            <when state="none" output="Z"/>
+            <when state="grave accent" output="Z̀"/>
         </action>
-        <action id="19">
-            <when state="none" output="y"/>
-            <when state="s4" output="ÿ"/>
+        <action id="k">
+            <when state="none" output="k"/>
+            <when state="grave accent" output="k̀"/>
+        </action>
+        <action id="m">
+            <when state="none" output="m"/>
+            <when state="grave accent" output="m̀"/>
+        </action>
+        <action id="q">
+            <when state="none" output="q"/>
+        </action>
+        <action id="r">
+            <when state="none" output="r"/>
+            <when state="grave accent" output="r̀"/>
+        </action>
+        <action id="s">
+            <when state="none" output="s"/>
+            <when state="grave accent" output="s̀"/>
+        </action>
+        <action id="t">
+            <when state="none" output="t"/>
+            <when state="grave accent" output="t̀"/>
+        </action>
+        <action id="v">
+            <when state="none" output="v"/>
+            <when state="grave accent" output="v̀"/>
+        </action>
+        <action id="w">
+            <when state="none" output="w"/>
+            <when state="grave accent" output="ẁ"/>
+        </action>
+        <action id="x">
+            <when state="none" output="x"/>
+            <when state="grave accent" output="x̀"/>
+        </action>
+        <action id="z">
+            <when state="none" output="z"/>
+            <when state="grave accent" output="z̀"/>
         </action>
     </actions>
     <terminators>
+        <when state="grave accent" output="`"/>
         <when state="s1" output="è"/>
         <when state="s2" output="`"/>
         <when state="s3" output="ì"/>

--- a/mac/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
+++ b/mac/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
@@ -49,7 +49,7 @@
             <key code="2" output="d"/>
             <key code="3" output="f"/>
             <key code="4" output="h"/>
-            <key code="5" output="g"/>
+            <key code="5" action="g"/>
             <key code="6" action="z"/>
             <key code="7" action="x"/>
             <key code="8" output="c"/>
@@ -79,10 +79,10 @@
             <key code="32" action="18"/>
             <key code="33" output="["/>
             <key code="34" action="15"/>
-            <key code="35" output="p"/>
+            <key code="35" action="p"/>
             <key code="36" output="&#x000D;"/>
             <key code="37" output="l"/>
-            <key code="38" output="j"/>
+            <key code="38" action="j"/>
             <key code="39" output="&#x0027;"/>
             <key code="40" action="k"/>
             <key code="41" output=";"/>
@@ -161,7 +161,7 @@
             <key code="2" output="D"/>
             <key code="3" output="F"/>
             <key code="4" output="H"/>
-            <key code="5" output="G"/>
+            <key code="5" action="G"/>
             <key code="6" action="Z"/>
             <key code="7" action="X"/>
             <key code="8" output="C"/>
@@ -191,10 +191,10 @@
             <key code="32" action="11"/>
             <key code="33" output="{"/>
             <key code="34" action="8"/>
-            <key code="35" output="P"/>
+            <key code="35" action="P"/>
             <key code="36" output="&#x000D;"/>
             <key code="37" output="L"/>
-            <key code="38" output="J"/>
+            <key code="38" action="J"/>
             <key code="39" output="&#x0022;"/>
             <key code="40" action="K"/>
             <key code="41" output=":"/>
@@ -542,7 +542,7 @@
             <key code="47" output="°"/>
             <key code="48" output="&#x0009;"/>
             <key code="49" output="&#x202f;"/>
-            <key code="50" output="`"/>
+            <key code="50" action="`"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
             <key code="53" output="&#x001B;"/>
@@ -1036,6 +1036,7 @@
             <when state="s3" output="Ô"/>
             <when state="s4" output="Ö"/>
             <when state="s5" output="Õ"/>
+            <when state="tilde" output="Õ"/>
         </action>
         <action id="11">
             <when state="none" output="U"/>
@@ -1044,11 +1045,13 @@
             <when state="s2" output="Ù"/>
             <when state="s3" output="Û"/>
             <when state="s4" output="Ü"/>
+            <when state="tilde" output="Ũ"/>
         </action>
         <action id="12">
             <when state="none" output="Y"/>
             <when state="grave accent" output="Ỳ"/>
             <when state="s4" output="Ÿ"/>
+            <when state="tilde" output="Ỹ"/>
         </action>
         <action id="13">
             <when state="none" output="a"/>
@@ -1058,6 +1061,7 @@
             <when state="s3" output="â"/>
             <when state="s4" output="ä"/>
             <when state="s5" output="ã"/>
+            <when state="tilde" output="ã"/>
         </action>
         <action id="14">
             <when state="none" output="e"/>
@@ -1066,6 +1070,7 @@
             <when state="s2" output="è"/>
             <when state="s3" output="ê"/>
             <when state="s4" output="ë"/>
+            <when state="tilde" output="ẽ"/>
         </action>
         <action id="15">
             <when state="none" output="i"/>
@@ -1074,10 +1079,12 @@
             <when state="s2" output="ì"/>
             <when state="s3" output="î"/>
             <when state="s4" output="ï"/>
+            <when state="tilde" output="ĩ"/>
         </action>
         <action id="16">
             <when state="none" output="n"/>
             <when state="s5" output="ñ"/>
+            <when state="tilde" output="ñ"/>
         </action>
         <action id="17">
             <when state="none" output="o"/>
@@ -1087,6 +1094,7 @@
             <when state="s3" output="ô"/>
             <when state="s4" output="ö"/>
             <when state="s5" output="õ"/>
+            <when state="tilde" output="õ"/>
         </action>
         <action id="18">
             <when state="none" output="u"/>
@@ -1095,11 +1103,13 @@
             <when state="s2" output="ù"/>
             <when state="s3" output="û"/>
             <when state="s4" output="ü"/>
+            <when state="tilde" output="ũ"/>
         </action>
         <action id="19">
             <when state="none" output="y"/>
             <when state="grave accent" output="ỳ"/>
             <when state="s4" output="ÿ"/>
+            <when state="tilde" output="ỹ"/>
         </action>
         <action id="2">
             <when state="none" next="s3"/>
@@ -1132,6 +1142,7 @@
             <when state="s3" output="Â"/>
             <when state="s4" output="Ä"/>
             <when state="s5" output="Ã"/>
+            <when state="tilde" output="Ã"/>
         </action>
         <action id="7">
             <when state="none" output="E"/>
@@ -1140,6 +1151,7 @@
             <when state="s2" output="È"/>
             <when state="s3" output="Ê"/>
             <when state="s4" output="Ë"/>
+            <when state="tilde" output="Ẽ"/>
         </action>
         <action id="8">
             <when state="none" output="I"/>
@@ -1148,10 +1160,20 @@
             <when state="s2" output="Ì"/>
             <when state="s3" output="Î"/>
             <when state="s4" output="Ï"/>
+            <when state="tilde" output="Ĩ "/>
         </action>
         <action id="9">
             <when state="none" output="N"/>
             <when state="s5" output="Ñ"/>
+            <when state="tilde" output="Ñ"/>
+        </action>
+        <action id="G">
+            <when state="none" output="G"/>
+            <when state="tilde" output="G̃"/>
+        </action>
+        <action id="J">
+            <when state="none" output="J"/>
+            <when state="tilde" output="J̃"/>
         </action>
         <action id="K">
             <when state="none" output="K"/>
@@ -1160,10 +1182,16 @@
         <action id="M">
             <when state="none" output="M"/>
             <when state="grave accent" output="M̀"/>
+            <when state="tilde" output="M̃"/>
+        </action>
+        <action id="P">
+            <when state="none" output="P"/>
+            <when state="tilde" output="P̃"/>
         </action>
         <action id="R">
             <when state="none" output="R"/>
             <when state="grave accent" output="R̀"/>
+            <when state="tilde" output="R̃"/>
         </action>
         <action id="S">
             <when state="none" output="S"/>
@@ -1176,6 +1204,7 @@
         <action id="V">
             <when state="none" output="V"/>
             <when state="grave accent" output="V̀"/>
+            <when state="tilde" output="Ṽ"/>
         </action>
         <action id="W">
             <when state="none" output="W"/>
@@ -1189,6 +1218,17 @@
             <when state="none" output="Z"/>
             <when state="grave accent" output="Z̀"/>
         </action>
+        <action id="`">
+            <when state="none" next="tilde"/>
+        </action>
+        <action id="g">
+            <when state="none" output="g"/>
+            <when state="tilde" output="g̃"/>
+        </action>
+        <action id="j">
+            <when state="none" output="j"/>
+            <when state="tilde" output="j̃"/>
+        </action>
         <action id="k">
             <when state="none" output="k"/>
             <when state="grave accent" output="k̀"/>
@@ -1196,6 +1236,11 @@
         <action id="m">
             <when state="none" output="m"/>
             <when state="grave accent" output="m̀"/>
+            <when state="tilde" output="m̃"/>
+        </action>
+        <action id="p">
+            <when state="none" output="p"/>
+            <when state="tilde" output="p̃"/>
         </action>
         <action id="q">
             <when state="none" output="q"/>
@@ -1203,6 +1248,7 @@
         <action id="r">
             <when state="none" output="r"/>
             <when state="grave accent" output="r̀"/>
+            <when state="tilde" output="r̃"/>
         </action>
         <action id="s">
             <when state="none" output="s"/>
@@ -1215,6 +1261,7 @@
         <action id="v">
             <when state="none" output="v"/>
             <when state="grave accent" output="v̀"/>
+            <when state="tilde" output="ṽ"/>
         </action>
         <action id="w">
             <when state="none" output="w"/>
@@ -1236,5 +1283,6 @@
         <when state="s3" output="ì"/>
         <when state="s4" output="ù"/>
         <when state="s5" output="ñ"/>
+        <when state="tilde" output="~"/>
     </terminators>
 </keyboard>

--- a/mac/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
+++ b/mac/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
@@ -514,7 +514,7 @@
             <key code="19" output=""/>
             <key code="20" output="¯"/>
             <key code="21" output="Ê"/>
-            <key code="22" output=""/>
+            <key code="22" action="caron"/>
             <key code="23" output="£"/>
             <key code="24" output="±"/>
             <key code="25" output="Î"/>
@@ -1031,6 +1031,7 @@
         <action id="10">
             <when state="none" output="O"/>
             <when state="acute accent" output="Ó"/>
+            <when state="caron" output="Ǒ"/>
             <when state="cedilla" output="O̧"/>
             <when state="circumflex" output="Ô"/>
             <when state="diaeresis" output="Ö"/>
@@ -1045,6 +1046,7 @@
         <action id="11">
             <when state="none" output="U"/>
             <when state="acute accent" output="Ú"/>
+            <when state="caron" output="Ǔ"/>
             <when state="cedilla" output="U̧"/>
             <when state="circumflex" output="Û"/>
             <when state="diaeresis" output="Ü"/>
@@ -1058,6 +1060,7 @@
         <action id="12">
             <when state="none" output="Y"/>
             <when state="acute accent" output="Ý"/>
+            <when state="caron" output="Y̌"/>
             <when state="circumflex" output="Ŷ"/>
             <when state="diaeresis" output="Ÿ"/>
             <when state="grave accent" output="Ỳ"/>
@@ -1067,6 +1070,7 @@
         <action id="13">
             <when state="none" output="a"/>
             <when state="acute accent" output="á"/>
+            <when state="caron" output="ǎ"/>
             <when state="cedilla" output="a̧"/>
             <when state="circumflex" output="â"/>
             <when state="diaeresis" output="ä"/>
@@ -1081,6 +1085,7 @@
         <action id="14">
             <when state="none" output="e"/>
             <when state="acute accent" output="é"/>
+            <when state="caron" output="ě"/>
             <when state="cedilla" output="ȩ"/>
             <when state="circumflex" output="ê"/>
             <when state="diaeresis" output="ë"/>
@@ -1094,6 +1099,7 @@
         <action id="15">
             <when state="none" output="i"/>
             <when state="acute accent" output="í"/>
+            <when state="caron" output="ǐ"/>
             <when state="cedilla" output="i̧"/>
             <when state="circumflex" output="î"/>
             <when state="diaeresis" output="ï"/>
@@ -1107,6 +1113,7 @@
         <action id="16">
             <when state="none" output="n"/>
             <when state="acute accent" output="ń"/>
+            <when state="caron" output="ň"/>
             <when state="cedilla" output="ņ"/>
             <when state="circumflex" output="n̂"/>
             <when state="diaeresis" output="n̈"/>
@@ -1116,6 +1123,7 @@
         <action id="17">
             <when state="none" output="o"/>
             <when state="acute accent" output="ó"/>
+            <when state="caron" output="ǒ"/>
             <when state="cedilla" output="o̧"/>
             <when state="circumflex" output="ô"/>
             <when state="diaeresis" output="ö"/>
@@ -1130,6 +1138,7 @@
         <action id="18">
             <when state="none" output="u"/>
             <when state="acute accent" output="ú"/>
+            <when state="caron" output="ǔ"/>
             <when state="cedilla" output="u̧"/>
             <when state="circumflex" output="û"/>
             <when state="diaeresis" output="ü"/>
@@ -1143,6 +1152,7 @@
         <action id="19">
             <when state="none" output="y"/>
             <when state="acute accent" output="ý"/>
+            <when state="caron" output="y̌"/>
             <when state="circumflex" output="ŷ"/>
             <when state="diaeresis" output="ÿ"/>
             <when state="grave accent" output="ỳ"/>
@@ -1175,6 +1185,7 @@
         <action id="6">
             <when state="none" output="A"/>
             <when state="acute accent" output="Á"/>
+            <when state="caron" output="Ǎ"/>
             <when state="cedilla" output="A̧"/>
             <when state="circumflex" output="Â"/>
             <when state="diaeresis" output="Ä"/>
@@ -1189,6 +1200,7 @@
         <action id="7">
             <when state="none" output="E"/>
             <when state="acute accent" output="É"/>
+            <when state="caron" output="Ě"/>
             <when state="cedilla" output="Ȩ"/>
             <when state="circumflex" output="Ê"/>
             <when state="diaeresis" output="Ë"/>
@@ -1202,6 +1214,7 @@
         <action id="8">
             <when state="none" output="I"/>
             <when state="acute accent" output="Í"/>
+            <when state="caron" output="Ǐ"/>
             <when state="cedilla" output="I̧"/>
             <when state="circumflex" output="Î"/>
             <when state="diaeresis" output="Ï"/>
@@ -1215,6 +1228,7 @@
         <action id="9">
             <when state="none" output="N"/>
             <when state="acute accent" output="Ń"/>
+            <when state="caron" output="Ň"/>
             <when state="cedilla" output="Ņ"/>
             <when state="circumflex" output="N̂"/>
             <when state="diaeresis" output="N̈"/>
@@ -1224,6 +1238,7 @@
         <action id="B">
             <when state="none" output="B"/>
             <when state="acute accent" output="B́"/>
+            <when state="caron" output="B̌"/>
             <when state="cedilla" output="B̧"/>
             <when state="circumflex" output="B̂"/>
             <when state="diaeresis" output="B̈"/>
@@ -1231,6 +1246,7 @@
         <action id="C">
             <when state="none" output="C"/>
             <when state="acute accent" output="Ć"/>
+            <when state="caron" output="Č"/>
             <when state="cedilla" output="Ç"/>
             <when state="circumflex" output="Ĉ"/>
             <when state="diaeresis" output="C̈"/>
@@ -1238,16 +1254,19 @@
         <action id="D">
             <when state="none" output="D"/>
             <when state="acute accent" output="D́"/>
+            <when state="caron" output="Ď"/>
             <when state="cedilla" output="Ḑ"/>
             <when state="circumflex" output="D̂"/>
         </action>
         <action id="F">
             <when state="none" output="F"/>
             <when state="acute accent" output="F́"/>
+            <when state="caron" output="F̌"/>
         </action>
         <action id="G">
             <when state="none" output="G"/>
             <when state="acute accent" output="Ǵ"/>
+            <when state="caron" output="Ǧ"/>
             <when state="cedilla" output="Ģ"/>
             <when state="circumflex" output="Ĝ"/>
             <when state="tilde" output="G̃"/>
@@ -1255,6 +1274,7 @@
         <action id="H">
             <when state="none" output="H"/>
             <when state="acute accent" output="H́"/>
+            <when state="caron" output="Ȟ"/>
             <when state="cedilla" output="Ḩ"/>
             <when state="circumflex" output="Ĥ"/>
             <when state="diaeresis" output="Ḧ"/>
@@ -1262,6 +1282,7 @@
         <action id="J">
             <when state="none" output="J"/>
             <when state="acute accent" output="J́"/>
+            <when state="caron" output="J̌"/>
             <when state="circumflex" output="Ĵ"/>
             <when state="diaeresis" output="J̈"/>
             <when state="tilde" output="J̃"/>
@@ -1269,6 +1290,7 @@
         <action id="K">
             <when state="none" output="K"/>
             <when state="acute accent" output="Ḱ"/>
+            <when state="caron" output="Ǩ"/>
             <when state="cedilla" output="Ķ"/>
             <when state="circumflex" output="K̂"/>
             <when state="diaeresis" output="K̈"/>
@@ -1277,6 +1299,7 @@
         <action id="L">
             <when state="none" output="L"/>
             <when state="acute accent" output="Ĺ"/>
+            <when state="caron" output="Ľ"/>
             <when state="cedilla" output="Ļ"/>
             <when state="circumflex" output="L̂"/>
             <when state="diaeresis" output="L̈"/>
@@ -1284,6 +1307,7 @@
         <action id="M">
             <when state="none" output="M"/>
             <when state="acute accent" output="Ḿ"/>
+            <when state="caron" output="M̌"/>
             <when state="cedilla" output="M̧"/>
             <when state="circumflex" output="M̂"/>
             <when state="diaeresis" output="M̈"/>
@@ -1293,18 +1317,21 @@
         <action id="P">
             <when state="none" output="P"/>
             <when state="acute accent" output="Ṕ"/>
+            <when state="caron" output="P̌"/>
             <when state="diaeresis" output="P̈"/>
             <when state="tilde" output="P̃"/>
         </action>
         <action id="Q">
             <when state="none" output="Q"/>
             <when state="acute accent" output="Q́"/>
+            <when state="caron" output="Q̌"/>
             <when state="cedilla" output="Q̧"/>
             <when state="diaeresis" output="Q̈"/>
         </action>
         <action id="R">
             <when state="none" output="R"/>
             <when state="acute accent" output="Ŕ"/>
+            <when state="caron" output="Ř"/>
             <when state="cedilla" output="Ŗ"/>
             <when state="circumflex" output="R̂"/>
             <when state="grave accent" output="R̀"/>
@@ -1313,6 +1340,7 @@
         <action id="S">
             <when state="none" output="S"/>
             <when state="acute accent" output="Ś"/>
+            <when state="caron" output="Š"/>
             <when state="cedilla" output="Ş"/>
             <when state="circumflex" output="Ŝ"/>
             <when state="diaeresis" output="S̈"/>
@@ -1321,6 +1349,7 @@
         <action id="T">
             <when state="none" output="T"/>
             <when state="acute accent" output="T́"/>
+            <when state="caron" output="Ť"/>
             <when state="cedilla" output="Ţ"/>
             <when state="circumflex" output="T̂"/>
             <when state="diaeresis" output="T̈"/>
@@ -1329,6 +1358,7 @@
         <action id="V">
             <when state="none" output="V"/>
             <when state="acute accent" output="V́"/>
+            <when state="caron" output="V̌"/>
             <when state="circumflex" output="V̂"/>
             <when state="diaeresis" output="V̈"/>
             <when state="grave accent" output="V̀"/>
@@ -1337,6 +1367,7 @@
         <action id="W">
             <when state="none" output="W"/>
             <when state="acute accent" output="Ẃ"/>
+            <when state="caron" output="W̌"/>
             <when state="circumflex" output="Ŵ"/>
             <when state="diaeresis" output="Ẅ"/>
             <when state="grave accent" output="Ẁ"/>
@@ -1344,6 +1375,7 @@
         <action id="X">
             <when state="none" output="X"/>
             <when state="acute accent" output="X́"/>
+            <when state="caron" output="X̌"/>
             <when state="cedilla" output="X̧"/>
             <when state="circumflex" output="X̂"/>
             <when state="diaeresis" output="Ẍ"/>
@@ -1352,6 +1384,7 @@
         <action id="Z">
             <when state="none" output="Z"/>
             <when state="acute accent" output="Ź"/>
+            <when state="caron" output="Ž"/>
             <when state="cedilla" output="Z̧"/>
             <when state="circumflex" output="Ẑ"/>
             <when state="diaeresis" output="Z̈"/>
@@ -1363,6 +1396,7 @@
         <action id="b">
             <when state="none" output="b"/>
             <when state="acute accent" output="b́"/>
+            <when state="caron" output="b̌"/>
             <when state="cedilla" output="b̧"/>
             <when state="circumflex" output="b̂"/>
             <when state="diaeresis" output="b̈"/>
@@ -1370,9 +1404,13 @@
         <action id="c">
             <when state="none" output="c"/>
             <when state="acute accent" output="ć"/>
+            <when state="caron" output="č"/>
             <when state="cedilla" output="ç"/>
             <when state="circumflex" output="ĉ"/>
             <when state="diaeresis" output="c̈"/>
+        </action>
+        <action id="caron">
+            <when state="none" next="caron"/>
         </action>
         <action id="cedilla">
             <when state="none" next="cedilla"/>
@@ -1383,16 +1421,19 @@
         <action id="d">
             <when state="none" output="d"/>
             <when state="acute accent" output="d́"/>
+            <when state="caron" output="ď"/>
             <when state="cedilla" output="ḑ"/>
             <when state="circumflex" output="d̂"/>
         </action>
         <action id="f">
             <when state="none" output="f"/>
             <when state="acute accent" output="f́"/>
+            <when state="caron" output="f̌"/>
         </action>
         <action id="g">
             <when state="none" output="g"/>
             <when state="acute accent" output="ǵ"/>
+            <when state="caron" output="ǧ"/>
             <when state="cedilla" output="ģ"/>
             <when state="circumflex" output="ĝ"/>
             <when state="tilde" output="g̃"/>
@@ -1400,6 +1441,7 @@
         <action id="h">
             <when state="none" output="h"/>
             <when state="acute accent" output="h́"/>
+            <when state="caron" output="ȟ"/>
             <when state="cedilla" output="ḩ"/>
             <when state="circumflex" output="ĥ"/>
             <when state="diaeresis" output="ḧ"/>
@@ -1407,6 +1449,7 @@
         <action id="j">
             <when state="none" output="j"/>
             <when state="acute accent" output="ȷ́"/>
+            <when state="caron" output="ǰ"/>
             <when state="circumflex" output="ĵ"/>
             <when state="diaeresis" output="j̈"/>
             <when state="tilde" output="j̃"/>
@@ -1414,6 +1457,7 @@
         <action id="k">
             <when state="none" output="k"/>
             <when state="acute accent" output="ḱ"/>
+            <when state="caron" output="ǩ"/>
             <when state="cedilla" output="ķ"/>
             <when state="circumflex" output="k̂"/>
             <when state="diaeresis" output="k̈"/>
@@ -1422,6 +1466,7 @@
         <action id="l">
             <when state="none" output="l"/>
             <when state="acute accent" output="ĺ"/>
+            <when state="caron" output="ľ"/>
             <when state="cedilla" output="ļ"/>
             <when state="circumflex" output="l̂"/>
             <when state="diaeresis" output="l̈"/>
@@ -1429,6 +1474,7 @@
         <action id="m">
             <when state="none" output="m"/>
             <when state="acute accent" output="ḿ"/>
+            <when state="caron" output="m̌"/>
             <when state="cedilla" output="m̧"/>
             <when state="circumflex" output="m̂"/>
             <when state="diaeresis" output="m̈"/>
@@ -1438,18 +1484,21 @@
         <action id="p">
             <when state="none" output="p"/>
             <when state="acute accent" output="ṕ"/>
+            <when state="caron" output="p̌"/>
             <when state="diaeresis" output="p̈"/>
             <when state="tilde" output="p̃"/>
         </action>
         <action id="q">
             <when state="none" output="q"/>
             <when state="acute accent" output="q́"/>
+            <when state="caron" output="q̌"/>
             <when state="cedilla" output="q̧"/>
             <when state="diaeresis" output="q̈"/>
         </action>
         <action id="r">
             <when state="none" output="r"/>
             <when state="acute accent" output="ŕ"/>
+            <when state="caron" output="ř"/>
             <when state="cedilla" output="ŗ"/>
             <when state="circumflex" output="r̂"/>
             <when state="grave accent" output="r̀"/>
@@ -1458,6 +1507,7 @@
         <action id="s">
             <when state="none" output="s"/>
             <when state="acute accent" output="ś"/>
+            <when state="caron" output="š"/>
             <when state="cedilla" output="ş"/>
             <when state="circumflex" output="ŝ"/>
             <when state="diaeresis" output="s̈"/>
@@ -1466,6 +1516,7 @@
         <action id="t">
             <when state="none" output="t"/>
             <when state="acute accent" output="t́"/>
+            <when state="caron" output="ť"/>
             <when state="cedilla" output="ţ"/>
             <when state="circumflex" output="t̂"/>
             <when state="diaeresis" output="ẗ"/>
@@ -1474,6 +1525,7 @@
         <action id="v">
             <when state="none" output="v"/>
             <when state="acute accent" output="v́"/>
+            <when state="caron" output="v̌"/>
             <when state="circumflex" output="v̂"/>
             <when state="diaeresis" output="v̈"/>
             <when state="grave accent" output="v̀"/>
@@ -1482,6 +1534,7 @@
         <action id="w">
             <when state="none" output="w"/>
             <when state="acute accent" output="ẃ"/>
+            <when state="caron" output="w̌"/>
             <when state="circumflex" output="ŵ"/>
             <when state="diaeresis" output="ẅ"/>
             <when state="grave accent" output="ẁ"/>
@@ -1489,6 +1542,7 @@
         <action id="x">
             <when state="none" output="x"/>
             <when state="acute accent" output="x́"/>
+            <when state="caron" output="x̌"/>
             <when state="cedilla" output="x̧"/>
             <when state="circumflex" output="x̂"/>
             <when state="diaeresis" output="ẍ"/>
@@ -1497,6 +1551,7 @@
         <action id="z">
             <when state="none" output="z"/>
             <when state="acute accent" output="ź"/>
+            <when state="caron" output="ž"/>
             <when state="cedilla" output="z̧"/>
             <when state="circumflex" output="ẑ"/>
             <when state="diaeresis" output="z̈"/>
@@ -1511,6 +1566,7 @@
     </actions>
     <terminators>
         <when state="acute accent" output="&#x0027;"/>
+        <when state="caron" output="ˇ"/>
         <when state="cedilla" output="¸"/>
         <when state="circumflex" output="ˆ"/>
         <when state="diaeresis" output="¨"/>

--- a/mac/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
+++ b/mac/qwerty-fr.bundle/Contents/Resources/qwerty-fr.keylayout
@@ -539,7 +539,7 @@
             <key code="44" output="¿"/>
             <key code="45" output="Ñ"/>
             <key code="46" output="µ"/>
-            <key code="47" output="°"/>
+            <key code="47" action="°"/>
             <key code="48" output="&#x0009;"/>
             <key code="49" output="&#x202f;"/>
             <key code="50" action="`"/>
@@ -1036,6 +1036,7 @@
             <when state="circumflex" output="Ô"/>
             <when state="diaeresis" output="Ö"/>
             <when state="grave accent" output="Ò"/>
+            <when state="ring" output="O̊"/>
             <when state="s1" output="Ó"/>
             <when state="s2" output="Ò"/>
             <when state="s3" output="Ô"/>
@@ -1051,6 +1052,7 @@
             <when state="circumflex" output="Û"/>
             <when state="diaeresis" output="Ü"/>
             <when state="grave accent" output="Ù"/>
+            <when state="ring" output="Ů"/>
             <when state="s1" output="Ú"/>
             <when state="s2" output="Ù"/>
             <when state="s3" output="Û"/>
@@ -1064,6 +1066,7 @@
             <when state="circumflex" output="Ŷ"/>
             <when state="diaeresis" output="Ÿ"/>
             <when state="grave accent" output="Ỳ"/>
+            <when state="ring" output="Y̊"/>
             <when state="s4" output="Ÿ"/>
             <when state="tilde" output="Ỹ"/>
         </action>
@@ -1075,6 +1078,7 @@
             <when state="circumflex" output="â"/>
             <when state="diaeresis" output="ä"/>
             <when state="grave accent" output="à"/>
+            <when state="ring" output="å"/>
             <when state="s1" output="á"/>
             <when state="s2" output="à"/>
             <when state="s3" output="â"/>
@@ -1090,6 +1094,7 @@
             <when state="circumflex" output="ê"/>
             <when state="diaeresis" output="ë"/>
             <when state="grave accent" output="è"/>
+            <when state="ring" output="e̊"/>
             <when state="s1" output="é"/>
             <when state="s2" output="è"/>
             <when state="s3" output="ê"/>
@@ -1104,6 +1109,7 @@
             <when state="circumflex" output="î"/>
             <when state="diaeresis" output="ï"/>
             <when state="grave accent" output="ì"/>
+            <when state="ring" output="i̊"/>
             <when state="s1" output="í"/>
             <when state="s2" output="ì"/>
             <when state="s3" output="î"/>
@@ -1128,6 +1134,7 @@
             <when state="circumflex" output="ô"/>
             <when state="diaeresis" output="ö"/>
             <when state="grave accent" output="ò"/>
+            <when state="ring" output="o̊"/>
             <when state="s1" output="ó"/>
             <when state="s2" output="ò"/>
             <when state="s3" output="ô"/>
@@ -1143,6 +1150,7 @@
             <when state="circumflex" output="û"/>
             <when state="diaeresis" output="ü"/>
             <when state="grave accent" output="ù"/>
+            <when state="ring" output="ů"/>
             <when state="s1" output="ú"/>
             <when state="s2" output="ù"/>
             <when state="s3" output="û"/>
@@ -1156,6 +1164,7 @@
             <when state="circumflex" output="ŷ"/>
             <when state="diaeresis" output="ÿ"/>
             <when state="grave accent" output="ỳ"/>
+            <when state="ring" output="ẙ"/>
             <when state="s4" output="ÿ"/>
             <when state="tilde" output="ỹ"/>
         </action>
@@ -1190,6 +1199,7 @@
             <when state="circumflex" output="Â"/>
             <when state="diaeresis" output="Ä"/>
             <when state="grave accent" output="À"/>
+            <when state="ring" output="Å"/>
             <when state="s1" output="Á"/>
             <when state="s2" output="À"/>
             <when state="s3" output="Â"/>
@@ -1205,6 +1215,7 @@
             <when state="circumflex" output="Ê"/>
             <when state="diaeresis" output="Ë"/>
             <when state="grave accent" output="È"/>
+            <when state="ring" output="E̊"/>
             <when state="s1" output="É"/>
             <when state="s2" output="È"/>
             <when state="s3" output="Ê"/>
@@ -1219,6 +1230,7 @@
             <when state="circumflex" output="Î"/>
             <when state="diaeresis" output="Ï"/>
             <when state="grave accent" output="Ì"/>
+            <when state="ring" output="I̊"/>
             <when state="s1" output="Í"/>
             <when state="s2" output="Ì"/>
             <when state="s3" output="Î"/>
@@ -1257,6 +1269,7 @@
             <when state="caron" output="Ď"/>
             <when state="cedilla" output="Ḑ"/>
             <when state="circumflex" output="D̂"/>
+            <when state="ring" output="D̊"/>
         </action>
         <action id="F">
             <when state="none" output="F"/>
@@ -1269,6 +1282,7 @@
             <when state="caron" output="Ǧ"/>
             <when state="cedilla" output="Ģ"/>
             <when state="circumflex" output="Ĝ"/>
+            <when state="ring" output="G̊"/>
             <when state="tilde" output="G̃"/>
         </action>
         <action id="H">
@@ -1285,6 +1299,7 @@
             <when state="caron" output="J̌"/>
             <when state="circumflex" output="Ĵ"/>
             <when state="diaeresis" output="J̈"/>
+            <when state="ring" output="J̊"/>
             <when state="tilde" output="J̃"/>
         </action>
         <action id="K">
@@ -1327,6 +1342,7 @@
             <when state="caron" output="Q̌"/>
             <when state="cedilla" output="Q̧"/>
             <when state="diaeresis" output="Q̈"/>
+            <when state="ring" output="Q̊"/>
         </action>
         <action id="R">
             <when state="none" output="R"/>
@@ -1345,6 +1361,7 @@
             <when state="circumflex" output="Ŝ"/>
             <when state="diaeresis" output="S̈"/>
             <when state="grave accent" output="S̀"/>
+            <when state="ring" output="S̊"/>
         </action>
         <action id="T">
             <when state="none" output="T"/>
@@ -1362,6 +1379,7 @@
             <when state="circumflex" output="V̂"/>
             <when state="diaeresis" output="V̈"/>
             <when state="grave accent" output="V̀"/>
+            <when state="ring" output="V̊"/>
             <when state="tilde" output="Ṽ"/>
         </action>
         <action id="W">
@@ -1371,6 +1389,7 @@
             <when state="circumflex" output="Ŵ"/>
             <when state="diaeresis" output="Ẅ"/>
             <when state="grave accent" output="Ẁ"/>
+            <when state="ring" output="W̊"/>
         </action>
         <action id="X">
             <when state="none" output="X"/>
@@ -1380,6 +1399,7 @@
             <when state="circumflex" output="X̂"/>
             <when state="diaeresis" output="Ẍ"/>
             <when state="grave accent" output="X̀"/>
+            <when state="ring" output="X̊"/>
         </action>
         <action id="Z">
             <when state="none" output="Z"/>
@@ -1424,6 +1444,7 @@
             <when state="caron" output="ď"/>
             <when state="cedilla" output="ḑ"/>
             <when state="circumflex" output="d̂"/>
+            <when state="ring" output="d̊"/>
         </action>
         <action id="f">
             <when state="none" output="f"/>
@@ -1436,6 +1457,7 @@
             <when state="caron" output="ǧ"/>
             <when state="cedilla" output="ģ"/>
             <when state="circumflex" output="ĝ"/>
+            <when state="ring" output="g̊"/>
             <when state="tilde" output="g̃"/>
         </action>
         <action id="h">
@@ -1452,6 +1474,7 @@
             <when state="caron" output="ǰ"/>
             <when state="circumflex" output="ĵ"/>
             <when state="diaeresis" output="j̈"/>
+            <when state="ring" output="j̊"/>
             <when state="tilde" output="j̃"/>
         </action>
         <action id="k">
@@ -1494,6 +1517,7 @@
             <when state="caron" output="q̌"/>
             <when state="cedilla" output="q̧"/>
             <when state="diaeresis" output="q̈"/>
+            <when state="ring" output="q̊"/>
         </action>
         <action id="r">
             <when state="none" output="r"/>
@@ -1512,6 +1536,7 @@
             <when state="circumflex" output="ŝ"/>
             <when state="diaeresis" output="s̈"/>
             <when state="grave accent" output="s̀"/>
+            <when state="ring" output="s̊"/>
         </action>
         <action id="t">
             <when state="none" output="t"/>
@@ -1529,6 +1554,7 @@
             <when state="circumflex" output="v̂"/>
             <when state="diaeresis" output="v̈"/>
             <when state="grave accent" output="v̀"/>
+            <when state="ring" output="v̊"/>
             <when state="tilde" output="ṽ"/>
         </action>
         <action id="w">
@@ -1538,6 +1564,7 @@
             <when state="circumflex" output="ŵ"/>
             <when state="diaeresis" output="ẅ"/>
             <when state="grave accent" output="ẁ"/>
+            <when state="ring" output="ẘ"/>
         </action>
         <action id="x">
             <when state="none" output="x"/>
@@ -1547,6 +1574,7 @@
             <when state="circumflex" output="x̂"/>
             <when state="diaeresis" output="ẍ"/>
             <when state="grave accent" output="x̀"/>
+            <when state="ring" output="x̊"/>
         </action>
         <action id="z">
             <when state="none" output="z"/>
@@ -1560,6 +1588,9 @@
         <action id="¨">
             <when state="none" next="diaeresis"/>
         </action>
+        <action id="°">
+            <when state="none" next="ring"/>
+        </action>
         <action id="ˊ">
             <when state="none" next="acute accent"/>
         </action>
@@ -1571,6 +1602,7 @@
         <when state="circumflex" output="ˆ"/>
         <when state="diaeresis" output="¨"/>
         <when state="grave accent" output="`"/>
+        <when state="ring" output="˚"/>
         <when state="s1" output="è"/>
         <when state="s2" output="`"/>
         <when state="s3" output="ì"/>


### PR DESCRIPTION
- Add dead keys:
  - grave accent
  - acute accent
  - tilde
  - cedilla
  - diaeresis
  - circumflex
  - caron
  - ring
- Fix incorrect and missing keys.

Let me know if anything is missing.